### PR TITLE
Return empty list when no entities are found (resolves #13)

### DIFF
--- a/REL/server.py
+++ b/REL/server.py
@@ -132,8 +132,9 @@ def make_handler(
             )
 
             # Singular document.
-            result = [*result.values()][0]
+            if len(result) > 0:
+                return [*result.values()][0]
 
-            return result
+            return []
 
     return GetHandler


### PR DESCRIPTION
If no entities are found, return empty list instead of throwing index bound error