### PR TITLE
Dockerize REL API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM pytorch/pytorch
 
 # download necessary files
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
     wget \
     tar
-RUN wget http://gem.cs.ru.nl/generic.tar.gz && tar xzf generic.tar.gz && rm generic.tar.gz
-RUN wget http://gem.cs.ru.nl/wiki_2019.tar.gz && tar xzf wiki_2019.tar.gz && rm wiki_2019.tar.gz
+RUN wget http://gem.cs.ru.nl/generic.tar.gz && tar xzf generic.tar.gz && rm generic.tar.gz && \
+    wget http://gem.cs.ru.nl/wiki_2019.tar.gz && tar xzf wiki_2019.tar.gz && rm wiki_2019.tar.gz
 
 # install REL
 RUN conda install -y pip
@@ -16,4 +17,4 @@ RUN git clone https://github.com/informagi/REL && cd REL && git checkout docker 
 EXPOSE 5555
 
 # run REL server
-ENTRYPOINT python -m rel.server ./ wiki_2019 --bind 0.0.0.0 --port 5555
+ENTRYPOINT python -m REL.server ./ wiki_2019 --bind 0.0.0.0 --port 5555

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# syntax = docker/dockerfile:experimental
+FROM pytorch/pytorch
+
+# download necessary files
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    tar
+RUN wget http://gem.cs.ru.nl/generic.tar.gz && tar xzf generic.tar.gz && rm generic.tar.gz
+RUN wget http://gem.cs.ru.nl/wiki_2019.tar.gz && tar xzf wiki_2019.tar.gz && rm wiki_2019.tar.gz
+
+# install REL
+RUN conda install -y pip
+RUN git clone https://github.com/informagi/REL && cd REL && git checkout docker && pip install -e . && cd ..
+
+# expose the API port
+EXPOSE 5555
+
+# run REL server
+ENTRYPOINT python REL/scripts/code_tutorials/run_server.py ./ wiki_2019

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN git clone https://github.com/informagi/REL && cd REL && git checkout docker 
 EXPOSE 5555
 
 # run REL server
-ENTRYPOINT python REL/scripts/code_tutorials/run_server.py ./ wiki_2019
+ENTRYPOINT python -m rel.server ./ wiki_2019 --bind 0.0.0.0 --port 5555

--- a/README.md
+++ b/README.md
@@ -44,11 +44,33 @@ API_result = requests.post("{}".format(IP_ADDRESS), json=document).json()
 # Setup package
 This section describes how to deploy REL on a local machine and setup the API.
 
-## Installation
+## Installation using Docker
+To build the Docker image yourself, run:
+```bash
+# Clone the repository
+git clone https://github.com/informagi/REL && cd REL
+# Build the Docker image
+docker build - -t informagi/rel < Dockerfile
+```
+The build process will automatically download all necessary files.
+
+To run the API locally:
+```bash
+# Map container port 5555 to local port 5555
+docker run -p 5555:5555 --rm -it informagi/rel
+# Or automatically generate port mapping
+docker run -P --rm -it informagi/rel
+```
+
+Now you can make requests to `http://localhost:5555` (or another port if you
+use a different mapping) in the format described in the example above.
+
+## Installation from source
 Run the following command in a terminal to install REL:
 ```
 pip install git+https://github.com/informagi/REL
 ```
+You will also need to manually download the files described in the next section.
 
 ## Download
 The files used for this project can be divided into three categories. The first is a generic set of documents and embeddings that was used throughout the project. This folder includes the GloVe embeddings used by Le et al. and the unprocessed datasets that were used to train

--- a/README.md
+++ b/README.md
@@ -52,7 +52,14 @@ git clone https://github.com/informagi/REL && cd REL
 # Build the Docker image
 docker build - -t informagi/rel < Dockerfile
 ```
-The build process will automatically download all necessary files.
+The build process will automatically download all necessary files. Wikipedia
+version 2019 is used by default - to specify the Wikipedia version (either 2019
+or 2014), pass e.g. `--build-arg WIKI_YEAR=2014` to the `docker build`
+command:
+
+```bash
+docker build - -t informagi/rel --build-arg WIKI_YEAR=2014 < Dockerfile
+```
 
 To run the API locally:
 ```bash

--- a/REL/server.py
+++ b/REL/server.py
@@ -155,7 +155,7 @@ if __name__ == "__main__":
     p.add_argument("--ed-model", default="ed-wiki-2019")
     p.add_argument("--ner-model", default="ner-fast")
     p.add_argument("--bind", "-b", metavar="ADDRESS", default="0.0.0.0")
-    p.add_argument("--port", "-p", default="5555")
+    p.add_argument("--port", "-p", default=5555, type=int)
     args = p.parse_args()
 
     ner_model = load_flair_ner(args.ner_model)

--- a/scripts/code_tutorials/run_server.py
+++ b/scripts/code_tutorials/run_server.py
@@ -1,42 +1,29 @@
-import argparse
 from http.server import HTTPServer
 
 from REL.entity_disambiguation import EntityDisambiguation
 from REL.ner import load_flair_ner
 from REL.server import make_handler
 
-p = argparse.ArgumentParser()
-p.add_argument("base_url")
-p.add_argument("wiki_version")
-p.add_argument("--ed-model", default="ed-wiki-2019")
-p.add_argument("--ner-tagger", default="ner-fast")
-p.add_argument("--port", type=int, default=5555)
-args = p.parse_args()
+# 0. Set your project url, which is used as a reference for your datasets etc.
+base_url = "/users/vanhulsm/Desktop/projects/data/"
+wiki_version = "wiki_2014"
 
-# Set some arguments
-base_url = args.base_url
-wiki_version = args.wiki_version
-port = args.port
-ed_model = args.ed_model
-ner_tagger = args.ner_tagger
-
-# Init model, where user can set his/her own config that will overwrite the default
-# config.  If mode is equal to 'eval', then the model_path should point to an existing
-# model (alias/path/URL).
+# 1. Init model, where user can set his/her own config that will overwrite the default config.
+# If mode is equal to 'eval', then the model_path should point to an existing model.
 config = {
     "mode": "eval",
-    "model_path": ed_model,
+    "model_path": "{}/{}/generated/model".format(base_url, wiki_version),
 }
 
 model = EntityDisambiguation(base_url, wiki_version, config)
 
 # 2. Create NER-tagger.
-ner_tagger = load_flair_ner(ner_tagger)  # or another tagger
+tagger_ner = load_flair_ner("ner-fast")  # or another tagger
 
 # 3. Init server.
-server_address = ("0.0.0.0", port)
+server_address = ("127.0.0.1", 5555)
 server = HTTPServer(
-    server_address, make_handler(base_url, wiki_version, model, ner_tagger),
+    server_address, make_handler(base_url, wiki_version, model, tagger_ner),
 )
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     description="Entity Linking package",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/mickvanhulst/rel",
+    url="https://github.com/informagi/REL",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Just need to link building the image to Dockerhub so people can just pull it, instead of having to build the image themselves. That will take some preparation with user permissions etc, it would probably be necessary to create a separate build team/user/account: https://docs.docker.com/docker-hub/builds/#service-users-for-team-autobuilds

This PR adds a Dockerfile to build a REL API executable (see the added text in the README). The Dockerfile can be edited to use e.g. different wiki versions, models and so on. This allows for a two-line package setup that eliminates manual downloading of data et cetera.

I personally need this for use on the UMC cluster, but I think it is a nice addition for other users as well.