### PR TITLE
Fixes FileNotFoundError

### DIFF
--- a/REL/wikipedia_yago_freq.py
+++ b/REL/wikipedia_yago_freq.py
@@ -176,7 +176,7 @@ class WikipediaYagoFreq:
 
         cnt = 0
         crosswiki_path = os.path.join(
-            self.base_url, "/generic/p_e_m_data/crosswikis_p_e_m.txt"
+            self.base_url, "generic/p_e_m_data/crosswikis_p_e_m.txt"
         )
 
         with open(crosswiki_path, "r", encoding="utf-8") as f:
@@ -240,13 +240,13 @@ class WikipediaYagoFreq:
         exist_id_found = False
 
         wiki_anchor_files = os.listdir(
-            os.path.join(self.base_url, self.wiki_version, "/basic_data/anchor_files/")
+            os.path.join(self.base_url, self.wiki_version, "basic_data/anchor_files/")
         )
         for wiki_anchor in wiki_anchor_files:
             wiki_file = os.path.join(
                 self.base_url,
                 self.wiki_version,
-                "/basic_data/anchor_files/",
+                "basic_data/anchor_files/",
                 wiki_anchor,
             )
 


### PR DESCRIPTION
Executing the program decribed [here](https://github.com/informagi/REL/blob/master/scripts/code_tutorials/generate_p_e_m.py) using the appropriate project/data folder settings, gave me the following error:
> `FileNotFoundError: [Errno 2] No such file or directory: '/basic_data/anchor_files/'`

Searching the [documentation](https://docs.python.org/3/library/os.path.html#os.path.join) I found the cause: the function `os.path.join` only uses the final argument passed through because it starts with a forward slash (`/`) and is therefore considered an absolute path. The documentation says the following:
> If a component is an absolute path, all previous components are thrown away and joining continues from the absolute path component.