### PR TITLE
Updated flair variable names

### DIFF
--- a/REL/mention_detection.py
+++ b/REL/mention_detection.py
@@ -146,8 +146,8 @@ class MentionDetection(MentionDetectionBase):
                 ):
                     text, start_pos, end_pos, conf, tag = (
                         entity.text,
-                        entity.start_pos,
-                        entity.end_pos,
+                        entity.start_position,
+                        entity.end_position,
                         entity.score,
                         entity.tag,
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorama
 konoha
-flair
+flair>=0.11
 segtok
 Pillow>=7.1.0
 torch


### PR DESCRIPTION
Running `scripts/efficiency_test.py` results in the error `File "scripts/efficiency_test.py", line 71, AttributeError: 'Span' object has no attribute 'start_pos'`. Two steps were taken to get rid of this error:

* the names of the variables at lines 149 and 150 of `REL/mention_detection.py` were updated
* version 0.11 or higher was added as the minimum version of `flair` to prevent installation of the software with a version with the old variable name

To test this update:

1. install version 011 of `flair`: `pip install flair==0.11.1`
2. go to the REL directory: `cd REL`
3. install the software: `pip install .`
4. run the test: `python3 scripts/efficiency_test.py` and verify that the error message appears
5. install this pull request
6. update the software: `pip install .`
7.  run the test: `python3 scripts/efficiency_test.py` and verify that the error message is gone