### PR TITLE
gerbil middleware run problems fix

### DIFF
--- a/scripts/gerbil_middleware/Makefile
+++ b/scripts/gerbil_middleware/Makefile
@@ -1,10 +1,10 @@
 default: build dockerize
 
 build:
-    mvn clean package -U
+	mvn clean package -U
 
 dockerize:
-    docker build -t git.project-hobbit.eu:4567/gerbil/spotwrapnifws4test .
+	docker build -t git.project-hobbit.eu:4567/gerbil/spotwrapnifws4test .
 
 push:
-    docker push git.project-hobbit.eu:4567/gerbil/spotwrapnifws4test
+	docker push git.project-hobbit.eu:4567/gerbil/spotwrapnifws4test

--- a/scripts/gerbil_middleware/pom.xml
+++ b/scripts/gerbil_middleware/pom.xml
@@ -76,7 +76,7 @@
 		<dependency>
 			<groupId>org.apache.jena</groupId>
 			<artifactId>jena-core</artifactId>
-			<version>4.2.0</version>
+			<version>2.11.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.jena</groupId>
@@ -116,6 +116,11 @@
 					<source>${java.version}</source>
 					<target>${java.version}</target>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>3.3.1</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
When running the gerbil middleware, I encountered the following error messages: 

1. `java.lang.NoClassDefFoundError: com/hp/hpl/jena/reasoner/Reasoner`:can be fixed by changing the jena version from 4.2.0 to 2.11.1 on line 79 in the file REL/scripts/gerbil_middleware/pom.xml
2. `Unable to load the mojo 'war'`: can be fixed by explicitly adding war as a plugin in the file REL/scripts/gerbil_middleware/pom.xml
3. `Makefile:4: *** missing separator.  Stop.`: can be fixed by changing the spaces in the file REL/scripts/gerbil_middleware/Makefile to tabs

Both problems have been fixed in the attached new version of the files pom.xml and Makefile