### PR TITLE
Ignore scripts dir for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
-[pytest]
+[tool.pytest.ini_options]
 addopts = "--ignore scripts/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[pytest]
+addopts = "--ignore scripts/"


### PR DESCRIPTION
Hi all, this PR excludes the scripts dir from being picked up by `pytest`.

Closes #109