### PR TITLE
tutorial: fix link to deploy REL new wiki

### DIFF
--- a/docs/tutorials/reproducing_our_results.md
+++ b/docs/tutorials/reproducing_our_results.md
@@ -3,7 +3,7 @@
 To reproduce our results there are various steps that need to be taken. The first step is making sure that the user
 has downloaded the respective download folders on our main Github folder. Here we politely refer the user to our tutorial on 
 [how to get started](../how_to_get_started/). Now that we have obtained
-the required folder structure, which includes the necessary training, validation and test files, we need [to train our Entity Disambiguation model](../deploy_rel_new_wiki/#training-your-own-entity-disambiguation-model). 
+the required folder structure, which includes the necessary training, validation and test files, we need [to train our Entity Disambiguation model](../deploy_REL_new_wiki/#training-your-own-entity-disambiguation-model). 
 
 To train a ED model for Wikipedia 2014, no extra changes are required. To obtain results for Wikipedia 2019, we note that the parameter `"dev_f1_change_lr"` needs to 
 be changed to `0.88`. After following these steps, the user now has access to a Entity Disambiguation model. In our paper we divide our results into three tables, which


### PR DESCRIPTION
just found this link had not been updated and fixed it.