### PR TITLE
Coreference search with LSH

### DIFF
--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -9,11 +9,18 @@ from REL.training_datasets import TrainingEvaluationDatasets
 np.random.seed(seed=42)
 
 parser = argparse.ArgumentParser()
-parser.add_argument( 
-    "--no_corefs",
-    action="store_true",
-    help="use function with_coref()?", 
-    default=False)
+# parser.add_argument( 
+#     "--no_corefs",
+#     action="store_true",
+#     help="use function with_coref()?", 
+#     default=False)
+parser.add_argument(
+    '--search_corefs',
+    type=str,
+    choices=['all', 'lsh', 'off'],
+    default='all',
+    help="Setting for search_corefs in Entity Disambiguation."
+)
 
 parser.add_argument(
     "--profile",
@@ -70,7 +77,7 @@ def profile_to_df(call):
 # adjust folder structure on computer and in script 
 
 args = parser.parse_args()
-print(f"args.no_corefs is {args.no_corefs}")
+print(f"args.search_corefs is {args.search_corefs}")
 
 if args.profile:
     import cProfile 
@@ -81,7 +88,7 @@ if args.profile:
 
 base_url = "/home/flavio/projects/rel20/data"
 wiki_version = "wiki_2019"
-datasets = TrainingEvaluationDatasets(base_url, wiki_version, args.no_corefs).load()[args.name_dataset] 
+datasets = TrainingEvaluationDatasets(base_url, wiki_version, args.search_corefs).load()[args.name_dataset] 
 save_data_to = f"{base_url}/efficiency_test/" # save all recorded in this directory 
 
 # random_docs = np.random.choice(list(datasets.keys()), 50)
@@ -151,7 +158,7 @@ if not server:
         "mode": "eval",
         "model_path": "{}/{}/generated/model".format(base_url, wiki_version),
     }
-    model = EntityDisambiguation(base_url, wiki_version, config, no_corefs=args.no_corefs) # TODO: change to no_corefs to be consistent!
+    model = EntityDisambiguation(base_url, wiki_version, config, search_corefs=args.search_corefs) 
         # model.coref is a training data set
         # model.coref has method with_coref
         # compare the training data sets when using corefs and when not
@@ -168,9 +175,9 @@ if not server:
         "timing": timing
     }
     
-    filename = f"{save_data_to}predictions/{args.name_dataset}_{args.n_docs}"
-    if args.no_corefs:
-        filename = f"{filename}_nocoref"
+    filename = f"{save_data_to}predictions/{args.name_dataset}_{args.n_docs}_{args.search_corefs}"
+    # if args.no_corefs:
+    #     filename = f"{filename}_nocoref"
 
     with open(f"{filename}.pickle", "wb") as f:
         pickle.dump(output, f, protocol=pickle.HIGHEST_PROTOCOL)        
@@ -178,9 +185,9 @@ if not server:
     # ## 4.b Profile disambiguation
     if args.profile:
         print("Profiling disambiguation")
-        filename = f"{save_data_to}profile/{args.name_dataset}_{args.n_docs}"
-        if args.no_corefs:
-            filename = f"{filename}_nocoref"
+        filename = f"{save_data_to}profile/{args.name_dataset}_{args.n_docs}_{args.search_corefs}"
+        # if args.no_corefs:
+        #     filename = f"{filename}_nocoref"
 
         df_stats = profile_to_df(call="model.predict(mentions_dataset)")
         # cProfile.run("model.predict(mentions_dataset)", filename="temp.txt")
@@ -237,9 +244,9 @@ if not server:
 
         
         # save timing by dataet
-        filename = f"{save_data_to}n_mentions_time/{args.name_dataset}"
-        if args.no_corefs:
-            filename = f"{filename}_nocoref"
+        filename = f"{save_data_to}n_mentions_time/{args.name_dataset}_{args.search_corefs}"
+        # if args.no_corefs:
+        #     filename = f"{filename}_nocoref"
         
         with open(f"{filename}.pickle", "wb") as f:
             pickle.dump(timing_by_dataset, f, protocol=pickle.HIGHEST_PROTOCOL)

--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -1,17 +1,27 @@
 import numpy as np
 import requests
+import argparse
+import pickle
 
 from REL.training_datasets import TrainingEvaluationDatasets
 
 np.random.seed(seed=42)
 
-base_url = "/Users/vanhulsm/Desktop/projects/data/"
-wiki_version = "wiki_2014"
-datasets = TrainingEvaluationDatasets(base_url, wiki_version).load()["aida_testB"]
+parser = argparse.ArgumentParser()
+parser.add_argument("--use_corefs", action="store_true", help="use function with_coref()?", default=False)
+args = parser.parse_args()
+print(f"args.use_corefs is {args.use_corefs}")
+
+
+
+base_url = "/home/flavio/projects/rel20/data"
+wiki_version = "wiki_2019"
+datasets = TrainingEvaluationDatasets(base_url, wiki_version, args.use_corefs).load()["aida_testB"] 
+    # datasets are loaded here, then processed and stored in docs, which is then used to check the efficiency
 
 # random_docs = np.random.choice(list(datasets.keys()), 50)
 
-server = True
+server = False
 docs = {}
 for i, doc in enumerate(datasets):
     sentences = []
@@ -56,9 +66,9 @@ if not server:
     from REL.entity_disambiguation import EntityDisambiguation
     from REL.mention_detection import MentionDetection
 
-    base_url = "C:/Users/mickv/desktop/data_back/"
+    # base_url = "C:/Users/mickv/desktop/data_back/" # why is this defined again here?
 
-    flair.device = torch.device("cuda:0")
+    flair.device = torch.device("cpu")
 
     mention_detection = MentionDetection(base_url, wiki_version)
 
@@ -66,7 +76,9 @@ if not server:
     tagger_ner = SequenceTagger.load("ner-fast")
 
     start = time()
-    mentions_dataset, n_mentions = mention_detection.find_mentions(docs, tagger_ner)
+    mentions_dataset, n_mentions = mention_detection.find_mentions(docs, tagger_ner) # TODO: here corefs have an impact! check how.
+        # but what we do in the mention detection here has no impact on what we below in ED. 
+        # so would we expect an effect here, or only below?
     print("MD took: {}".format(time() - start))
 
     # 3. Load model.
@@ -74,9 +86,26 @@ if not server:
         "mode": "eval",
         "model_path": "{}/{}/generated/model".format(base_url, wiki_version),
     }
-    model = EntityDisambiguation(base_url, wiki_version, config)
+    model = EntityDisambiguation(base_url, wiki_version, config, use_corefs=args.use_corefs)
+        # model.coref is a training data set
+        # model.coref has method with_coref
+        # compare the training data sets when using corefs and when not
+        # note that the data are loaded elsewhere! so not sure this is the right place to add the option? 
 
     # 4. Entity disambiguation.
     start = time()
     predictions, timing = model.predict(mentions_dataset)
     print("ED took: {}".format(time() - start))
+
+    output = {
+        "predictions": predictions,
+        "timing": timing
+    }
+    fn = f"{base_url}/efficiency_test/output"
+    if not args.use_corefs:
+        fn = f"{fn}_nocoref"
+
+    with open(f"{fn}.pickle", "wb") as f:
+        pickle.dump(output, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    

--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -217,6 +217,7 @@ if not server:
     # ## 4.c time disambiguation by document, vary number of mentions 
     if args.scale_mentions:
         print("Scaling the mentions per document")
+        logging.basicConfig(level=logging.DEBUG) 
         mentions_dataset_scaled = {}
 
         for k, data in mentions_dataset.items():
@@ -229,7 +230,7 @@ if not server:
         print("Timing disambiguation per document")
         timing_by_dataset = {}
         for name, mentions in mentions_dataset_scaled.items():
-            print(f"predicting for dataset {name}")
+            print(f"predicting for dataset {name}", flush=True)
             tempdict = {name: mentions} # format so that model.predict() works 
             start = time()
             predictions, timing = model.predict(tempdict)

--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -13,7 +13,10 @@ from REL.training_datasets import TrainingEvaluationDatasets
 np.random.seed(seed=42)
 
 def profile_to_df(call):
-    "Helper function to profile a function call and save the timing in a pd df"
+    """Helper function to profile a function call and save the timing in a pd df.
+
+    Source: https://stackoverflow.com/questions/44302726/pandas-how-to-store-cprofile-output-in-a-pandas-dataframe
+    """
     cProfile.run(call, filename="temp.txt")
     st = pstats.Stats("temp.txt")
 

--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -80,7 +80,19 @@ print(f"args.search_corefs is {args.search_corefs}")
 base_url = "/home/flavio/projects/rel20/data"
 wiki_version = "wiki_2019"
 datasets = TrainingEvaluationDatasets(base_url, wiki_version, args.search_corefs).load()[args.name_dataset] 
-save_data_to = f"{base_url}/efficiency_test/" # save all recorded data in this directory 
+
+# create directories where to save the output from the tests
+dir_efficiency_test = os.path.join(base_url, "efficiency_test")
+sub_directories = {
+    "profile": "profile",
+    "predictions": "predictions",
+    "n_mentions_time": "n_mentions_time"
+}
+sub_directories = {k: os.path.join(dir_efficiency_test, v) for k, v in sub_directories.items()}
+
+for d in sub_directories.values():
+    if not os.path.exists(d):
+        os.makedirs(d)
 
 
 server = False
@@ -159,7 +171,8 @@ if not server:
         "timing": timing
     }
     
-    filename = f"{save_data_to}predictions/{args.name_dataset}_{args.n_docs}_{args.search_corefs}"
+    iteration_identifier = f"{args.name_dataset}_{args.n_docs}_{args.search_corefs}"
+    filename = os.path.join(sub_directories["predictions"], iteration_identifier)
 
     with open(f"{filename}.pickle", "wb") as f:
         pickle.dump(output, f, protocol=pickle.HIGHEST_PROTOCOL)        
@@ -167,7 +180,7 @@ if not server:
     # ## 4.b Profile the disambiguation part 
     if args.profile:
         print("Profiling disambiguation")
-        filename = f"{save_data_to}profile/{args.name_dataset}_{args.n_docs}_{args.search_corefs}"
+        filename = os.path.join(sub_directories["profile"], iteration_identifier)
 
         df_stats = profile_to_df(call="model.predict(mentions_dataset)")
         df_stats.to_csv(f"{filename}.csv", index=False)
@@ -205,7 +218,7 @@ if not server:
                 timing_by_dataset[name]['profile'] = df_profile
         
         # save timing by dataset
-        filename = f"{save_data_to}n_mentions_time/{args.name_dataset}_{args.search_corefs}"
+        filename = os.path.join(sub_directories["n_mentions_time"], f"{args.name_dataset}_{args.search_corefs}" )
 
         with open(f"{filename}.pickle", "wb") as f:
             pickle.dump(timing_by_dataset, f, protocol=pickle.HIGHEST_PROTOCOL)

--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -2,7 +2,7 @@ import numpy as np
 import requests
 import argparse
 import pickle
-
+import logging 
 
 from REL.training_datasets import TrainingEvaluationDatasets
 
@@ -47,6 +47,8 @@ parser.add_argument(
     default=50,
     help="Number of documents to be processed."
 )
+logging.basicConfig(level=logging.INFO) # do not print to file 
+
 
 # helper function to profile a call and save the timing in a pd dataframe 
 def profile_to_df(call):

--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -3,21 +3,86 @@ import requests
 import argparse
 import pickle
 
+
 from REL.training_datasets import TrainingEvaluationDatasets
 
 np.random.seed(seed=42)
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--use_corefs", action="store_true", help="use function with_coref()?", default=False)
-args = parser.parse_args()
-print(f"args.use_corefs is {args.use_corefs}")
+parser.add_argument( 
+    "--no_corefs",
+    action="store_true",
+    help="use function with_coref()?", 
+    default=False)
 
+parser.add_argument(
+    "--profile",
+    action="store_true",
+    default=False,
+    help="Profile the disambiguation step."
+    )
+parser.add_argument(
+    "--scale_mentions",
+    action="store_true", 
+    default=False,
+    help="""Stack mentions in each dataset and time the disambiguation step by document. 
+            This is to assess the time complexity of the program."""
+    )
+parser.add_argument(
+    "--name_dataset",
+    type=str,
+    default="aida_testB",
+    help="Name of the training dataset to be used"
+)
+parser.add_argument(
+    "--n_docs",
+    type=int,
+    default=50,
+    help="Number of documents to be processed."
+)
+
+# helper function to profile a call and save the timing in a pd dataframe 
+def profile_to_df(call):
+    cProfile.run(call, filename="temp.txt")
+    st = pstats.Stats("temp.txt")
+
+    keys_from_k = ['file', 'line', 'fn']
+    keys_from_v = ['cc', 'ncalls', 'tottime', 'cumtime', 'callers']
+    data = {k: [] for k in keys_from_k + keys_from_v}
+
+    s = st.stats
+
+    for k in s.keys():
+        for i, kk in enumerate(keys_from_k):
+            data[kk].append(k[i])
+
+        for i, kk in enumerate(keys_from_v):
+            data[kk].append(s[k][i])
+
+    df = pd.DataFrame(data)
+    os.remove('temp.txt')
+    return df
+
+
+
+# TODO:
+# make log files!?
+# adjust folder structure on computer and in script 
+
+args = parser.parse_args()
+print(f"args.no_corefs is {args.no_corefs}")
+
+if args.profile:
+    import cProfile 
+    import pandas as pd 
+    import pstats 
+    import os 
 
 
 base_url = "/home/flavio/projects/rel20/data"
 wiki_version = "wiki_2019"
-datasets = TrainingEvaluationDatasets(base_url, wiki_version, args.use_corefs).load()["aida_testB"] 
-    # datasets are loaded here, then processed and stored in docs, which is then used to check the efficiency
+datasets = TrainingEvaluationDatasets(base_url, wiki_version, args.no_corefs).load()[args.name_dataset] 
+save_data_to = f"{base_url}/efficiency_test/" # save all recorded in this directory 
 
 # random_docs = np.random.choice(list(datasets.keys()), 50)
 
@@ -30,8 +95,8 @@ for i, doc in enumerate(datasets):
             sentences.append(x["sentence"])
     text = ". ".join([x for x in sentences])
 
-    if len(docs) == 50:
-        print("length docs is 50.")
+    if len(docs) == args.n_docs:
+        print(f"length docs is {args.n_docs}.")
         print("====================")
         break
 
@@ -86,7 +151,7 @@ if not server:
         "mode": "eval",
         "model_path": "{}/{}/generated/model".format(base_url, wiki_version),
     }
-    model = EntityDisambiguation(base_url, wiki_version, config, use_corefs=args.use_corefs)
+    model = EntityDisambiguation(base_url, wiki_version, config, no_corefs=args.no_corefs) # TODO: change to no_corefs to be consistent!
         # model.coref is a training data set
         # model.coref has method with_coref
         # compare the training data sets when using corefs and when not
@@ -97,56 +162,87 @@ if not server:
     predictions, timing = model.predict(mentions_dataset)
     print("ED took: {}".format(time() - start))
 
-
-    # scale the number of mentions
-    # max_scaling_factor = 10
-    # steps = 5
-
-    mentions_dataset_scaled = {}
-
-    for k, data in mentions_dataset.items():
-        mentions_dataset_scaled[k] = data # add the baseline data as in mentions_dataset
-        for f in [5, 10, 50, 100]:
-            d = data * f 
-            key = f"{k}_{f}"
-            mentions_dataset_scaled[key] = d
-
-    timing_by_dataset = {}
-    for name, mentions in mentions_dataset_scaled.items():
-        print(f"predicting for dataset {name}")
-        tempdict = {name: mentions} # format so that model.predict() works 
-        start = time()
-        predictions, timing = model.predict(tempdict)
-        t = time() - start
-        timing_by_dataset[name] = {
-            "n_mentions": len(mentions),
-            "time": t
-        }
-
-    import cProfile 
-    fn = f"{base_url}/efficiency_test/profile_predict"
-    if not args.use_corefs:
-        fn = f"{fn}_nocoref"
-    # cProfile.run("model.predict(mentions_dataset_scaled)", sort=1, filename=fn)
-    # breakpoint()
-
     output = {
         "predictions": predictions,
         "timing": timing
     }
-    fn = f"{base_url}/efficiency_test/output"
-    if not args.use_corefs:
-        fn = f"{fn}_nocoref"
+    
+    filename = f"{save_data_to}predictions/{args.name_dataset}_{args.n_docs}"
+    if args.no_corefs:
+        filename = f"{filename}_nocoref"
 
-    with open(f"{fn}.pickle", "wb") as f:
-        pickle.dump(output, f, protocol=pickle.HIGHEST_PROTOCOL)
-    
-    # save timing by dataet
-    fn_time_dataset = f"{base_url}/efficiency_test/time_dataset"
-    if not args.use_corefs:
-        fn_time_dataset = f"{fn_time_dataset}_nocoref"
-    
-    with open(f"{fn_time_dataset}.pickle", "wb") as f:
-        pickle.dump(timing_by_dataset, f, protocol=pickle.HIGHEST_PROTOCOL)
+    with open(f"{filename}.pickle", "wb") as f:
+        pickle.dump(output, f, protocol=pickle.HIGHEST_PROTOCOL)        
+
+    # ## 4.b Profile disambiguation
+    if args.profile:
+        print("Profiling disambiguation")
+        filename = f"{save_data_to}profile/{args.name_dataset}_{args.n_docs}"
+        if args.no_corefs:
+            filename = f"{filename}_nocoref"
+
+        df_stats = profile_to_df(call="model.predict(mentions_dataset)")
+        # cProfile.run("model.predict(mentions_dataset)", filename="temp.txt")
+        # st = pstats.Stats("temp.txt")
+
+        # keys_from_k = ['file', 'line', 'fn']
+        # keys_from_v = ['cc', 'ncalls', 'tottime', 'cumtime', 'callers']
+        # data = {k: [] for k in keys_from_k + keys_from_v}
+
+        # s = st.stats
+
+        # for k in s.keys():
+        #     for i, kk in enumerate(keys_from_k):
+        #         data[kk].append(k[i])
+
+        #     for i, kk in enumerate(keys_from_v):
+        #         data[kk].append(s[k][i])
+
+        # df_stats = pd.DataFrame(data)
+        # os.remove('temp.txt')
+
+        df_stats.to_csv(f"{filename}.csv", index=False)
+
+
+    # ## 4.c time disambiguation by document, vary number of mentions 
+    if args.scale_mentions:
+        print("Scaling the mentions per document")
+        mentions_dataset_scaled = {}
+
+        for k, data in mentions_dataset.items():
+            mentions_dataset_scaled[k] = data # add the baseline data as in mentions_dataset
+            for f in [5, 10, 50, 100]:
+                d = data * f 
+                key = f"{k}_{f}"
+                mentions_dataset_scaled[key] = d
+
+        print("Timing disambiguation per document")
+        timing_by_dataset = {}
+        for name, mentions in mentions_dataset_scaled.items():
+            print(f"predicting for dataset {name}")
+            tempdict = {name: mentions} # format so that model.predict() works 
+            start = time()
+            predictions, timing = model.predict(tempdict)
+            t = time() - start
+
+            timing_by_dataset[name] = {
+                "n_mentions": len(mentions),
+                "time": t
+            }
+            
+            if args.profile:
+                df_profile = profile_to_df(call="model.predict(tempdict)") 
+                timing_by_dataset[name]['profile'] = df_profile
+
+        
+        # save timing by dataet
+        filename = f"{save_data_to}n_mentions_time/{args.name_dataset}"
+        if args.no_corefs:
+            filename = f"{filename}_nocoref"
+        
+        with open(f"{filename}.pickle", "wb") as f:
+            pickle.dump(timing_by_dataset, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+
 
     

--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -1,13 +1,16 @@
-import requests
 import argparse
-import pickle
-import logging 
 import cProfile 
+import logging 
+import numpy as np 
+import os 
+import pickle
 import pandas as pd 
 import pstats 
-import os 
+import requests
 
 from REL.training_datasets import TrainingEvaluationDatasets
+
+np.random.seed(seed=42)
 
 def profile_to_df(call):
     "Helper function to profile a function call and save the timing in a pd df"

--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -222,7 +222,7 @@ if not server:
 
         for k, data in mentions_dataset.items():
             mentions_dataset_scaled[k] = data # add the baseline data as in mentions_dataset
-            for f in [5, 50, 100, 300]:
+            for f in [5, 50, 100]:
                 d = data * f 
                 key = f"{k}_{f}"
                 mentions_dataset_scaled[key] = d
@@ -242,6 +242,7 @@ if not server:
             }
             
             if args.profile:
+                print("Profiling disambiguation for synthetic data set")
                 df_profile = profile_to_df(call="model.predict(tempdict)") 
                 timing_by_dataset[name]['profile'] = df_profile
 

--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -163,6 +163,7 @@ if not server:
     print("ED took: {}".format(time() - start))
 
     output = {
+        "mentions": mentions_dataset,
         "predictions": predictions,
         "timing": timing
     }

--- a/scripts/efficiency_test.py
+++ b/scripts/efficiency_test.py
@@ -221,7 +221,7 @@ if not server:
 
         for k, data in mentions_dataset.items():
             mentions_dataset_scaled[k] = data # add the baseline data as in mentions_dataset
-            for f in [5, 10, 50, 100]:
+            for f in [5, 50, 100, 300]:
                 d = data * f 
                 key = f"{k}_{f}"
                 mentions_dataset_scaled[key] = d

--- a/scripts/run_efficiency_tests.sh
+++ b/scripts/run_efficiency_tests.sh
@@ -12,23 +12,23 @@ echo $datasets
 echo "--Running efficiency tests by data set and n_docs--"
 
 # do profiling and checking predictions in one 
-for size in ${docsizes[@]}; do
-    for ds in ${datasets[@]}; do
-        echo $ds, echo $size
-        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
-        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
-        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
-    done 
-done 
+# for size in ${docsizes[@]}; do
+#     for ds in ${datasets[@]}; do
+#         echo $ds, echo $size
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
+#     done 
+# done 
 
 echo "--Scaling number of mentions--"
 
-# for ds in ${datasets[@]}; do
-#     echo $ds
-#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
-#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
-#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
-# done 
+for ds in ${datasets[@]}; do
+    echo $ds
+    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
+    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
+    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
+done 
 
 
 echo "Done."

--- a/scripts/run_efficiency_tests.sh
+++ b/scripts/run_efficiency_tests.sh
@@ -12,16 +12,18 @@ echo $datasets
 for size in ${docsizes[@]}; do
     for ds in ${datasets[@]}; do
         echo $ds, echo $size
-        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds"
-        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --no_corefs
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
     done 
 done 
 
 
 # for ds in ${datasets[@]}; do
 #     echo $ds
-#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile 
-#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --no_corefs
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
 # done 
 
 

--- a/scripts/run_efficiency_tests.sh
+++ b/scripts/run_efficiency_tests.sh
@@ -1,0 +1,31 @@
+
+
+
+datasets=("aida_testB")
+
+docsizes=(50 500)
+
+
+echo $datasets
+
+# do profiling and checking predictions in one 
+# for size in ${docsizes[@]}; do
+#     for ds in ${datasets[@]}; do
+#         echo $ds, echo $size
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds"
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --no_corefs
+#     done 
+# done 
+
+
+for ds in ${datasets[@]}; do
+    echo $ds
+    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile 
+    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --no_corefs
+done 
+
+
+
+
+
+

--- a/scripts/run_efficiency_tests.sh
+++ b/scripts/run_efficiency_tests.sh
@@ -19,15 +19,15 @@ for size in ${docsizes[@]}; do
 done 
 
 
-# for ds in ${datasets[@]}; do
-#     echo $ds
-#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
-#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
-#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
-# done 
+for ds in ${datasets[@]}; do
+    echo $ds
+    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
+    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
+    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
+done 
 
 
-
+echo "Done."
 
 
 

--- a/scripts/run_efficiency_tests.sh
+++ b/scripts/run_efficiency_tests.sh
@@ -12,22 +12,22 @@ echo $datasets
 echo "--Running efficiency tests by data set and n_docs--"
 
 # do profiling and checking predictions in one 
-for size in ${docsizes[@]}; do
-    for ds in ${datasets[@]}; do
-        echo $ds, echo $size
-        # python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
-        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
-        # python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
-    done 
-done 
+# for size in ${docsizes[@]}; do
+#     for ds in ${datasets[@]}; do
+#         echo $ds, echo $size
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
+#     done 
+# done 
 
 echo "--Scaling number of mentions--"
 
 for ds in ${datasets[@]}; do
     echo $ds
-    # python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
+    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
-    # python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
+    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
 done 
 
 

--- a/scripts/run_efficiency_tests.sh
+++ b/scripts/run_efficiency_tests.sh
@@ -9,14 +9,14 @@ docsizes=(50 500)
 echo $datasets
 
 # do profiling and checking predictions in one 
-for size in ${docsizes[@]}; do
-    for ds in ${datasets[@]}; do
-        echo $ds, echo $size
-        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
-        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
-        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
-    done 
-done 
+# for size in ${docsizes[@]}; do
+#     for ds in ${datasets[@]}; do
+#         echo $ds, echo $size
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
+#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
+#     done 
+# done 
 
 
 for ds in ${datasets[@]}; do

--- a/scripts/run_efficiency_tests.sh
+++ b/scripts/run_efficiency_tests.sh
@@ -9,20 +9,20 @@ docsizes=(50 500)
 echo $datasets
 
 # do profiling and checking predictions in one 
-# for size in ${docsizes[@]}; do
-#     for ds in ${datasets[@]}; do
-#         echo $ds, echo $size
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds"
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --no_corefs
-#     done 
-# done 
-
-
-for ds in ${datasets[@]}; do
-    echo $ds
-    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile 
-    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --no_corefs
+for size in ${docsizes[@]}; do
+    for ds in ${datasets[@]}; do
+        echo $ds, echo $size
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds"
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --no_corefs
+    done 
 done 
+
+
+# for ds in ${datasets[@]}; do
+#     echo $ds
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile 
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --no_corefs
+# done 
 
 
 

--- a/scripts/run_efficiency_tests.sh
+++ b/scripts/run_efficiency_tests.sh
@@ -8,22 +8,26 @@ docsizes=(50 500)
 
 echo $datasets
 
-# do profiling and checking predictions in one 
-# for size in ${docsizes[@]}; do
-#     for ds in ${datasets[@]}; do
-#         echo $ds, echo $size
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
-#     done 
-# done 
 
+echo "--Running efficiency tests by data set and n_docs--"
+
+# do profiling and checking predictions in one 
+for size in ${docsizes[@]}; do
+    for ds in ${datasets[@]}; do
+        echo $ds, echo $size
+        # python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
+        # python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
+    done 
+done 
+
+echo "--Scaling number of mentions--"
 
 for ds in ${datasets[@]}; do
     echo $ds
-    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
+    # python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
-    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
+    # python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
 done 
 
 

--- a/scripts/run_efficiency_tests.sh
+++ b/scripts/run_efficiency_tests.sh
@@ -12,23 +12,23 @@ echo $datasets
 echo "--Running efficiency tests by data set and n_docs--"
 
 # do profiling and checking predictions in one 
-# for size in ${docsizes[@]}; do
-#     for ds in ${datasets[@]}; do
-#         echo $ds, echo $size
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
-#     done 
-# done 
+for size in ${docsizes[@]}; do
+    for ds in ${datasets[@]}; do
+        echo $ds, echo $size
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
+    done 
+done 
 
 echo "--Scaling number of mentions--"
 
-for ds in ${datasets[@]}; do
-    echo $ds
-    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
-    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
-    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
-done 
+# for ds in ${datasets[@]}; do
+#     echo $ds
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
+# done 
 
 
 echo "Done."

--- a/scripts/run_efficiency_tests.sh
+++ b/scripts/run_efficiency_tests.sh
@@ -12,23 +12,23 @@ echo $datasets
 echo "--Running efficiency tests by data set and n_docs--"
 
 # do profiling and checking predictions in one 
-# for size in ${docsizes[@]}; do
-#     for ds in ${datasets[@]}; do
-#         echo $ds, echo $size
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
-#         python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
-#     done 
-# done 
-
-echo "--Scaling number of mentions--"
-
-for ds in ${datasets[@]}; do
-    echo $ds
-    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
-    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
-    python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
+for size in ${docsizes[@]}; do
+    for ds in ${datasets[@]}; do
+        echo $ds, echo $size
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "all"
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "lsh"
+        python scripts/efficiency_test.py --profile --n_docs $size --name_dataset "$ds" --search_corefs "off"
+    done 
 done 
+
+# echo "--Scaling number of mentions--"
+
+# for ds in ${datasets[@]}; do
+#     echo $ds
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "all"
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "lsh"
+#     python scripts/efficiency_test.py --name_dataset "$ds" --scale_mentions --profile --search_corefs "off"
+# done 
 
 
 echo "Done."

--- a/src/REL/entity_disambiguation.py
+++ b/src/REL/entity_disambiguation.py
@@ -32,7 +32,7 @@ class EntityDisambiguation:
     Parent Entity Disambiguation class that directs the various subclasses used
     for the ED step.
     """
-    def __init__(self, base_url, wiki_version, user_config, reset_embeddings=False, use_corefs=True):
+    def __init__(self, base_url, wiki_version, user_config, reset_embeddings=False, no_corefs=False):
         self.base_url = base_url
         self.wiki_version = wiki_version
         self.embeddings = {}
@@ -53,8 +53,8 @@ class EntityDisambiguation:
         ), "Glove embeddings in wrong folder..? Test embedding not found.."
 
         self.__load_embeddings()
-        self.use_corefs = use_corefs
-        self.coref = TrainingEvaluationDatasets(base_url, wiki_version, use_corefs)
+        self.no_corefs = no_corefs
+        self.coref = TrainingEvaluationDatasets(base_url, wiki_version, no_corefs)
         self.prerank_model = PreRank(self.config).to(self.device)
 
         self.__max_conf = None
@@ -471,7 +471,7 @@ class EntityDisambiguation:
         :return: predictions and time taken for the ED step.
         """
 
-        if self.use_corefs:
+        if not self.no_corefs:
             self.coref.with_coref(data)
             
         data = self.get_data_items(data, "raw", predict=True)

--- a/src/REL/entity_disambiguation.py
+++ b/src/REL/entity_disambiguation.py
@@ -473,7 +473,7 @@ class EntityDisambiguation:
 
         if not self.no_corefs:
             self.coref.with_coref(data)
-            
+
         data = self.get_data_items(data, "raw", predict=True)
         predictions, timing = self.__predict(data, include_timing=True, eval_raw=True)
 
@@ -667,7 +667,12 @@ class EntityDisambiguation:
                 ]
                 doc_names = [m["doc_name"] for m in batch]
 
-                for dname, entity in zip(doc_names, pred_entities):
+                if not self.no_corefs:
+                    coref_indicators = [m['raw']['is_coref'] for m in batch]
+                else:
+                    coref_indicators = [None for m in batch]
+
+                for dname, entity, is_coref in zip(doc_names, pred_entities, coref_indicators):
                     if entity[0] != "NIL":
                         predictions[dname].append(
                             {
@@ -676,6 +681,7 @@ class EntityDisambiguation:
                                 "candidates": entity[2],
                                 "conf_ed": entity[4],
                                 "scores": list([str(x) for x in entity[3]]),
+                                "is_coref": is_coref
                             }
                         )
 
@@ -686,6 +692,7 @@ class EntityDisambiguation:
                                 "prediction": entity[0],
                                 "candidates": entity[2],
                                 "scores": [],
+                                "is_coref": is_coref
                             }
                         )
 

--- a/src/REL/entity_disambiguation.py
+++ b/src/REL/entity_disambiguation.py
@@ -32,7 +32,7 @@ class EntityDisambiguation:
     Parent Entity Disambiguation class that directs the various subclasses used
     for the ED step.
     """
-    def __init__(self, base_url, wiki_version, user_config, reset_embeddings=False):
+    def __init__(self, base_url, wiki_version, user_config, reset_embeddings=False, use_corefs=True):
         self.base_url = base_url
         self.wiki_version = wiki_version
         self.embeddings = {}
@@ -53,7 +53,8 @@ class EntityDisambiguation:
         ), "Glove embeddings in wrong folder..? Test embedding not found.."
 
         self.__load_embeddings()
-        self.coref = TrainingEvaluationDatasets(base_url, wiki_version)
+        self.use_corefs = use_corefs
+        self.coref = TrainingEvaluationDatasets(base_url, wiki_version, use_corefs)
         self.prerank_model = PreRank(self.config).to(self.device)
 
         self.__max_conf = None
@@ -470,7 +471,9 @@ class EntityDisambiguation:
         :return: predictions and time taken for the ED step.
         """
 
-        self.coref.with_coref(data)
+        if self.use_corefs:
+            self.coref.with_coref(data)
+            
         data = self.get_data_items(data, "raw", predict=True)
         predictions, timing = self.__predict(data, include_timing=True, eval_raw=True)
 

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -17,6 +17,7 @@ import itertools
 from scipy import sparse
 import math 
 
+# First, define a bunch of functions. TODO: should they be defined elsewhere? utils?
 
 def k_shingle(s, k):
     """
@@ -84,7 +85,6 @@ def signature_to_3d_bands(a, n_bands, band_length):
     
     return result 
 
-# this replaces idx_multidim
 def group_unique_indices(a):
     """
     In a 3-dimensional array, for each array (axis 0), 
@@ -113,6 +113,8 @@ def group_unique_indices(a):
 
     return unq_idx
 
+# ## Here follow the classes
+
 class LSHBase:
     """
     Base class for locality-sensitive hashing, 
@@ -124,6 +126,10 @@ class LSHBase:
             self.shingles = [k_shingle(m, shingle_size) for m in mentions.values()]
         elif isinstance(mentions, list):
             self.shingles = [k_shingle(m, shingle_size) for m in mentions]
+
+    def __repr__(self):
+        #return f"{type(self).__name__}({self.shingles})"
+        pass 
 
     def _build_vocab(self):
         """
@@ -150,7 +156,7 @@ class LSHRandomProjections(LSHBase):
     
     Parameters:
     -----------
-    mentions: list of strings (mentions).
+    mentions: list or dict of mentions.
 
     shingle_size: length of the shingles to be constructed from each string in `mentions`.
 
@@ -251,8 +257,7 @@ class LSHRandomProjections(LSHBase):
     def efficiency_gain_comparisons(self):
         """
         Compare number of comparisons made for coreference search with option "lsh" and option "all".
-        Useful for understanding time complexity. 
-        And to assess whether number of comparisons is meaningfully reduced
+        Useful for understanding time complexity, and to assess whether number of comparisons is meaningfully reduced
         """
         sizes = [len(g) for g in self.candidates]
         runtime_all = len(self.candidates)*len(self.candidates)

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -14,9 +14,10 @@ import itertools
 import logging 
 import math 
 import numpy as np 
+import time 
+
 from scipy import sparse
 from sklearn.preprocessing import MultiLabelBinarizer
-import time 
 
 # First, define a bunch of functions. TODO: should they be defined elsewhere? put in utils?
 
@@ -89,7 +90,7 @@ def signature_to_3d_bands(a, n_bands, band_length):
     stacked_bands = a.reshape(n_items*n_bands, band_length) 
     # reorder so that the first band of all items comes first, then the second band of all items, etc.
     reordering_vector = np.arange(n_items*n_bands).reshape(n_items, n_bands).T.reshape(1, -1)
-    
+
     result = stacked_bands[reordering_vector, :].reshape(n_bands, n_items, band_length)
     return result 
 
@@ -144,7 +145,7 @@ class LSHBase:
     encode_binary()
         One-hot encode mentions, based on shingles
     """
-    # Important: order of occurences in shingles and vectors = order of input list (=order of occurrence in document)
+    
     def __init__(self, mentions, shingle_size):
         """
 
@@ -311,7 +312,6 @@ class LSHRandomProjections(LSHBase):
         self._build_vocab()
         self.encode_binary()
 
-        logging.debug("making signature")
         if self.vectors.shape[1] == 0: # no signature possible b/c no mention is longer than the shingle size.
             self._all_candidates_to_all()
         else:
@@ -334,4 +334,4 @@ class LSHRandomProjections(LSHBase):
         sizes = [len(g) for g in self.candidates]
         runtime_all = len(self.candidates) * len(self.candidates)
         runtime_lsh = len(self.candidates) * (sum(sizes)/len(sizes))
-        print(f"LSH makes fraction {round(runtime_lsh/runtime_all, 2)} of comparisons relative to option all.")
+        print(f"option 'lsh' makes fraction {round(runtime_lsh/runtime_all, 2)} of comparisons relative to option 'all'.")

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -185,12 +185,15 @@ class LSHMinHash(LSHBase):
         # elif isinstance(self.vectors, sparse._coo.coo_matrix):
             # not sure how efficient this is. switching a lot between data structures.
             logging.debug('using binary sparse matrices')
-            rng = np.random.default_rng(seed=3)
+            rng = np.random.default_rng(seed=3) # TODO: put this to class instantiation
             # vectors = mylsh.vectors
+            logging.debug("making hyperplanes")
             hyperplanes = rng.choice([-1, 1], (self.signature_size, self.vectors.shape[1]))
             # TODO: make vectors a csr matrix (?)
             hyperplanes = sparse.csr_matrix(hyperplanes)
+            logging.debug("making dot product")
             products = self.vectors.dot(hyperplanes.transpose())
+            logging.debug("making signature")
             products = products.toarray()
             sign = 1 + (products > 0) # TODO: can I change the downstream function for this? now it should be much easier to transform the signatures into a single string?
             self.signature = sign

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -122,14 +122,20 @@ class LSHBase:
     """
     # Important: order of occurences in shingles and vectors = order of input list (=order of occurrence in document)
     def __init__(self, mentions, shingle_size):
+        self.shingle_size = shingle_size
         if isinstance(mentions, dict):
             self.shingles = [k_shingle(m, shingle_size) for m in mentions.values()]
         elif isinstance(mentions, list):
             self.shingles = [k_shingle(m, shingle_size) for m in mentions]
+        self._rep_items_not_show = ["shingles"]
 
     def __repr__(self):
-        #return f"{type(self).__name__}({self.shingles})"
-        pass 
+        items_dict_show = {k: v for k, v in self.__dict__.items() 
+                                if k not in self._rep_items_not_show
+                                and k[0] != "_"
+                            }
+        items_dict_show = [f"{k}={v}" for k, v in items_dict_show.items()]
+        return f"<{type(self).__name__}() with {', '.join(items_dict_show)}>"
 
     def _build_vocab(self):
         """
@@ -170,13 +176,15 @@ class LSHRandomProjections(LSHBase):
 
     def __init__(self, mentions, shingle_size, n_bands, band_length=None, seed=3):
         super().__init__(mentions, shingle_size)
+        self.seed = seed
         self.n_bands = n_bands
         if band_length is None:
             self.band_length = math.ceil(math.log(len(mentions))) # for O(log(N)) complexity
         else:
             self.band_length = band_length
         self.signature_size = n_bands * band_length 
-        self.rng = np.random.default_rng(seed=seed)
+        self.rng = np.random.default_rng(seed=self.seed)
+        self._rep_items_not_show.extend(["signature_size", "rng"])
     
     def make_signature(self):
         """

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -1,5 +1,5 @@
 """
-This implements a simple version of locality-sensitive hashing.
+Implement a simple version of locality-sensitive hashing.
 The main reference is chapter 3 in "Mining of Massive Datasets" (http://www.mmds.org/).
 
 To allow for high-dimensional data, it stores the feature vectors as sparse matrices,

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -115,8 +115,20 @@ class LSHBase:
         self.vectors = binarizer.fit_transform(self.shingles)
 
 
-class LSHMinHash(LSHBase):
-    "LSH with MinHashing and numpy"
+class LSHRandomProjections(LSHBase):
+    """
+    A class for locality-sensitive hashing with random projections.
+    
+
+    Parameters:
+    -----------
+    mentions:
+    shingle_size:
+    signature_size:
+    band_length:
+    seed:     
+    """
+    # TODO: document more 
 
     def __init__(self, mentions, shingle_size, signature_size, band_length, seed=3):
         # sparse_binary: should the sparse 0/1 matrix be stored with scipy sparse? takes less memory.

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -324,7 +324,7 @@ class LSHMinHash(LSHBase):
             bands = vectorize_signature_bands(self.signature, n_bands=n_bands, band_length=self.band_length)
             buckets_by_band = group_unique_indices(bands)
             groups = [tuple(i) for i in itertools.chain.from_iterable(buckets_by_band)] # flatten group; use tuple for applying set()
-            groups = set(groups) # we only need the unique clusters 
+            groups = set(groups) # we only need the unique groups 
 
             for group in groups:
                 for i in group:

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -11,11 +11,7 @@ import numpy as np
 import logging 
 from sklearn.preprocessing import MultiLabelBinarizer
 import itertools
-import pdb 
 from scipy import sparse
-
-# TODO:
-    # document the class? -- after swapping the arguments 
 
 
 def k_shingle(s, k):
@@ -148,19 +144,15 @@ class LSHRandomProjections(LSHBase):
     """
     Class for locality-sensitive hashing with random projections.
     
-
     Parameters:
     -----------
-    mentions:
-    shingle_size:
-    signature_size:
-    band_length:
-    seed:     
+    mentions: list of strings.
+    shingle_size: length of the shingles to be constructed from each string in `mentions`.
+    n_bands, band_length: cut the hash signature into `n_bands` subsets of length `band_length`.
+    seed: random seed for np.random.default_rng
     """
-    # TODO: document more 
 
     def __init__(self, mentions, shingle_size, n_bands, band_length, seed=3):
-        # sparse_binary: should the sparse 0/1 matrix be stored with scipy sparse? takes less memory.
         super().__init__(mentions, shingle_size)
         self.n_bands = n_bands
         self.band_length = band_length 

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -1,0 +1,190 @@
+
+from random import shuffle, seed 
+import time 
+import numpy as np 
+seed(3)
+
+def split_mention(m):
+    return m.split(" ")
+
+def k_shingle(s, k):
+    "convert string s into shingles of length k"
+    shingle = []
+    for i in range(len(s) - k + 1):
+        shingle.append(s[i:(i+k)])
+    return shingle
+
+
+def partition_signature(s, b):
+    "Convert signature s into b partitions of equal size"
+    assert len(s) % b == 0
+    rg = int(len(s) / b)
+    partitions = []
+    for i in range(0, len(s), rg):
+        v = s[i:i+rg]
+        partitions.append(v)
+    return partitions
+
+def cols_to_int(a):
+    "combine columns in all rows to an integer: [[1,20,3], [1,4,10]] becomes [1203,1410]"
+    existing_powers = np.floor(np.log10(a))
+    nrows, ncols = a.shape 
+
+    cumsum_powers = np.fliplr(np.cumsum(np.fliplr(existing_powers), axis=1))
+
+    add_powers = [x for x in reversed(range(ncols))]
+    add_powers = np.tile(add_powers, (nrows, 1))
+
+    mult_factor = cumsum_powers - existing_powers + add_powers  
+    summationvector = np.ones((ncols, 1)) 
+    out = np.matmul(a * 10**mult_factor, summationvector)
+    return out 
+
+
+
+def idx_unique_multidim(a):
+    "groups rows in a multidimensional arrays by their unique signature"
+    # a = cols_to_int(a).squeeze() # wrong
+    # a = cols_to_string(a).squeeze() # slow 
+    a = cols_to_int(a).squeeze()
+    sort_idx = np.argsort(a)
+    sort_idx
+    a_sorted = a[sort_idx]
+    unq_first = np.concatenate(([True], a_sorted[1:] != a_sorted[:-1])) # "is the current value different from the previous?". the concat of [True]: because the first occurrence is always True (ie the first time it occur)
+    unq_items = a_sorted[unq_first]
+    unq_count = np.diff(np.nonzero(unq_first)[0]) # np.nonzero(unq_first)[0] gives the indices of first elements in a_sorted
+    unq_idx = np.split(sort_idx, np.cumsum(unq_count))
+    return unq_idx
+
+
+def reshape_rows_reps(a):
+    "reshape a 3-d array of n_reps x n_rows x n_cols to n_rows x n_reps x n_cols"
+    n_reps, n_rows, n_cols = a.shape
+    a = a.reshape(n_reps*n_rows, n_cols)
+    # extractor indices: for 3 reps, 2 rows: [0,2,4,1,3,5]. to reorder a
+        # in other words: goes from 0 to (n_reps * n_rows). step sizes are n_rows. starts are the row indices
+    idx = np.arange(n_reps*n_rows).reshape(n_reps, n_rows).T.reshape(-1,1)
+    a = np.take_along_axis(a, idx, axis=0)
+    a = a.reshape(n_rows, n_reps, n_cols)
+    return a 
+
+def minhash_signature_np(x, n_reps):
+    """Make a minhash signature of array x with length n_reps.
+
+    Inputs
+    ------
+    x: axis 0 are observations, columns are binary one-hot encoded vectors
+    """
+    # get indices 
+    indices = np.arange(x.shape[1])
+    rng = np.random.default_rng(12345)
+
+    # expand by n_reps 
+    indices_mult = np.tile(indices, (n_reps, 1)) # reorder the columns n_reps times 
+    x_mult = np.tile(x, (n_reps, 1)).reshape((n_reps,) + x.shape) # new shape: (n_resp, x.shape[0], x.shape[1
+
+    # permute indices and apply to x_mult
+    permuted_indices = rng.permuted(indices_mult, axis=1)
+    x_mult_permuted = np.take_along_axis(x_mult, permuted_indices[:, np.newaxis], 2)
+
+    # for the reduction below, need to have all samples of the same observation in one block
+    x_mult_permuted = reshape_rows_reps(x_mult_permuted)
+
+    # make signature
+    sig = x_mult_permuted.argmax(axis=2)
+    return sig 
+
+
+class LSHBase:
+    # Important: order of occurences in shingles and vectors = order of input list (=order of occurrence in document)
+    def __init__(self, mentions, shingle_size):
+        if isinstance(mentions, dict):
+            self.shingles = [k_shingle(m, shingle_size) for m in mentions.values()]
+        elif isinstance(mentions, list):
+            self.shingles = [k_shingle(m, shingle_size) for m in mentions]
+
+    def _build_vocab(self):
+        # shingles = [v["shingles"] for v in self.mentions.values()]
+        vocab = list(set([shingle for sublist in self.shingles for shingle in sublist]))
+        self.vocab = vocab
+
+    def encode_binary(self, to_numpy=False):
+        vectors = [[1 if word in cur_shingles else 0 for word in self.vocab] for cur_shingles in self.shingles]
+        if not to_numpy:
+            self.vectors = vectors 
+        else:
+            self.vectors = np.stack(vectors)
+
+
+class LSHMinHash(LSHBase):
+    "LSH with MinHashing and numpy"
+
+    def __init__(self, mentions, shingle_size, signature_size, band_length):
+        super().__init__(mentions, shingle_size)
+        if signature_size % band_length != 0:
+            raise ValueError("Signature needs to be divisible into equal-sized bands.")
+        self.signature_size = signature_size 
+        self.band_length = band_length 
+    
+    def make_signature(self):
+        "make array of dense vectors with MinHashing. each row is one mention"
+        templist = []
+        rng = np.random.default_rng(seed=3)
+        i = 0
+        while i < self.signature_size:
+            rng.shuffle(self.vectors, axis=1)
+            sig_i = 1 + self.vectors.argmax(axis=1) # add one for the log10 operations in idx_unique_multidim 
+            templist.append(sig_i)
+            i += 1
+
+        self.signature = np.stack(templist, axis=1)
+
+    def make_signature_np(self):
+        signature = minhash_signature_np(self.vectors, self.signature_size)
+        self.signature = signature + np.ones(signature.shape)  # this is for the log10 operations: do not want to have 0s
+
+    def all_candidates_to_all(self):
+        "fall-back option to return the non-clustered input: each mention is a candidate coreference for all"
+        n_mentions = self.vectors.shape[0]
+        self.candidates = [set(range(n_mentions)) for _ in range(n_mentions)]
+
+    def get_candidates(self):
+        "extract similar candidates for each mention by comparing subsets of the signature"
+        n_bands = int(self.signature_size / self.band_length)
+        bands = np.split(ary=self.signature, indices_or_sections=n_bands, axis=1)
+        candidates = [set() for _ in range(self.vectors.shape[0])]
+
+        if len(candidates) > 1:
+            for band in bands:
+                groups = idx_unique_multidim(band)
+                groups = [g for g in groups if g.shape[0] > 1]
+                for g in groups:
+                    g = list(g)
+                    for i in g:
+                        for j in g:
+                            if i != j:
+                                candidates[i].add(j)
+        else: # idx_unique_multidim above does not work when there is only one candidate
+            candidates[0].add(0)
+
+        self.candidates = candidates
+
+    def cluster(self, numpy_signature=False):
+        "find similar records for each mention"
+        start = time.time()
+        self._build_vocab()
+        self.encode_binary(to_numpy=True)
+        if self.vectors.shape[1] == 0: # no signature possible b/c no mention is longer than the shingle size.
+            self.all_candidates_to_all()
+        else:
+            if numpy_signature:
+                self.make_signature_np()
+            else:
+                self.make_signature()
+            self.get_candidates()
+        self.time = time.time() - start 
+
+    def summarise(self):
+        sizes = [len(g) for g in self.candidates]
+        print(f"took {self.time} seconds for {len(self.candidates)} mentions")
+        print(f"average, min, max cluster size: {round(sum(sizes)/len(sizes),2)}, {min(sizes)}, {max(sizes)}")

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -20,7 +20,7 @@ import time
 # First, define a bunch of functions. TODO: should they be defined elsewhere? utils?
 
 def k_shingle(s, k):
-    "Convert string s into shingles of length k"
+    "Convert string s into shingles of length k."
     shingle = []
     for i in range(len(s) - k + 1):
         shingle.append(s[i:(i+k)])
@@ -28,16 +28,17 @@ def k_shingle(s, k):
 
 
 def cols_to_int_multidim(a):
-    """Combine columns in all rows to an integer
+    """Combine columns in all rows to an integer.
     
     For instance, [[1,20,3], [1,4,10]] becomes [1203,1410].
 
     Notes
     -----
-    The addvantage is that uses vectorized numpy to create a unique signature.
-    The disadvantage is that because one additional row increases the size of the integer at least 
-    by an order of magnitude, this only works for cases where the bands are not too large. 
-    But in practice, optimal bands are typically not long enough to cause problems.
+    The advantage is that it uses vectorized numpy to collapse an
+    entire row into one integer. The disadvantage is that because one additional row increases 
+    the size of the integer at least by an order of magnitude, this only works for cases where 
+    the bands are not too large. But in practice, optimal bands are typically not long enough 
+    to cause problems.
 
     :param a: 2-dimensional array
     :type a: np.ndarray
@@ -60,7 +61,7 @@ def cols_to_int_multidim(a):
     return out 
 
 def signature_to_3d_bands(a, n_bands, band_length):
-    """Convert a signature from 2d to 3d
+    """Convert a signature from 2d to 3d.
 
     Convert a signature array of dimension (n_items, signature_length) into an array 
     of (n_bands, n_items, band_length).
@@ -93,7 +94,7 @@ def signature_to_3d_bands(a, n_bands, band_length):
     return result 
 
 def group_unique_indices(a):
-    """Compute indices of matching rows
+    """Compute indices of matching rows.
 
     In a 3-dimensional array, for each array (axis 0), 
     compute the indices of rows (axis=1) that are identical.
@@ -187,8 +188,7 @@ class LSHBase:
 
 
 class LSHRandomProjections(LSHBase):
-    """
-    Class for locality-sensitive hashing with random projections.
+    """Class for locality-sensitive hashing with random projections.
     
     Attributes
     -----------
@@ -202,7 +202,7 @@ class LSHRandomProjections(LSHBase):
         If band_length is `None`, it is set as log(len(mentions)), which 
         will guarantee O(log(N)) time complexity.
     seed
-        random seed for np.random.default_rng
+        Random seed for np.random.default_rng
 
     Methods
     --------
@@ -217,7 +217,7 @@ class LSHRandomProjections(LSHBase):
         Summarise time and output of cluster()
     efficiency_gain_comparisons()
         Compare number of computations for coreference search with hashing 
-        and without hashing
+        and without hashing.
     """
 
     def __init__(self, mentions, shingle_size, n_bands, band_length=None, seed=3):
@@ -240,18 +240,17 @@ class LSHRandomProjections(LSHBase):
         self.seed = seed
         self.n_bands = n_bands
         if band_length is None:
-            self.band_length = math.ceil(math.log(len(mentions))) # for O(log(N)) complexity
+            log_n_mentions = math.ceil(math.log(len(mentions))) # for O(log(N)) complexity
+            self.band_length = max(1, log_n_mentions)
         else:
             self.band_length = band_length
-        self.signature_size = n_bands * band_length 
+        self.signature_size = n_bands * self.band_length 
         self.rng = np.random.default_rng(seed=self.seed)
         self._rep_items_not_show.extend(["signature_size", "rng"])
     
     def make_signature(self):
-        "Create a matrix of signatures with random projections"
+        "Create a matrix of signatures with random projections."
         logging.debug(f"Making signature. vectors shape is {self.vectors.shape}")
-        # TODO: can this be more memory-efficient by generating directly the scipy sparse function? 
-        # https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.random.html
         n_rows = self.signature_size
         n_cols = self.vectors.shape[1]
         hyperplanes = sparse.csr_matrix(
@@ -269,7 +268,7 @@ class LSHRandomProjections(LSHBase):
         self.candidates = [set(range(n_mentions)) for _ in range(n_mentions)]
 
     def get_candidates(self):
-        """Extract most similar mentions from signature
+        """Extract most similar mentions from signature.
 
         For each mention, extract most similar mentions based on whether part 
         of their signatures overlap.
@@ -299,7 +298,7 @@ class LSHRandomProjections(LSHBase):
         self.candidates = candidates
 
     def cluster(self): 
-        """End-to-end locality-sensitive hashing
+        """End-to-end locality-sensitive hashing.
 
         Cluster mentions together based on their similarity. 
 
@@ -330,8 +329,9 @@ class LSHRandomProjections(LSHBase):
 
     def efficiency_gain_comparisons(self):
         """
-        Compare number of comparisons made for coreference search with option "lsh" and option "all".
-        Useful for understanding time complexity, and to assess whether number of comparisons is meaningfully reduced
+        Compare number of comparisons made for coreference search with option 
+        "lsh" and option "all". Useful for understanding time complexity, 
+        and to assess whether number of comparisons is meaningfully reduced.
         """
         sizes = [len(g) for g in self.candidates]
         runtime_all = len(self.candidates)*len(self.candidates)

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -28,14 +28,15 @@ def cols_to_int_multidim(a):
     ------
     Advantage: uses vectorized numpy to create a unique signature.
     Disadvantage: Because one additional row increases the size of the integer at least by an order of magnitude, 
-    this only works for cases where the bands are not too large (otherwise integer overflow problems).
+    this only works for cases where the bands are not too large. 
 
     In practice I have found that optimal bands are typically not long enough to cause problems.
     """
     existing_powers = np.floor(np.log10(a))
     n_bands, nrows, ncols = a.shape 
 
-    cumsum_powers = np.fliplr(np.cumsum(np.fliplr(existing_powers), axis=1))
+    # cumsum_powers = np.fliplr(np.cumsum(np.fliplr(existing_powers), axis=1))
+    cumsum_powers = np.flip(np.cumsum(np.flip(existing_powers, axis=2), axis=2), axis=2)
 
     add_powers = [x for x in reversed(range(ncols))]
     add_powers = np.tile(add_powers, (nrows, 1))
@@ -66,11 +67,10 @@ def vectorize_signature_bands(a, n_bands, band_length):
 # this replaces idx_multidim
 def group_unique_indices(a):
     """
-    Calculate groups of indices of unique rows in a multidimensional array with the same signature
-    the groups are returned by band.
+    Calculate groups of indices of unique rows in a multidimensional array with the same signature.
 
     Returns a list of lists. One list corresponds to each band, and it indicates the rows
-    of a that have the same band.
+    of `a` that have the same band.
     """
     n_bands, n_items, length_band = a.shape
     a = cols_to_int_multidim(a).squeeze()

--- a/src/REL/lsh.py
+++ b/src/REL/lsh.py
@@ -1,15 +1,11 @@
 
-from random import shuffle, seed 
 import time 
 import numpy as np 
 import logging 
-from collections import defaultdict
 from sklearn.preprocessing import MultiLabelBinarizer
 import itertools
 import pdb 
-import sys 
 from scipy import sparse
-seed(3)
 
 
 def k_shingle(s, k):
@@ -20,92 +16,22 @@ def k_shingle(s, k):
     return shingle
 
 
-# def cols_to_int(a):
-#     "combine columns in all rows to an integer: [[1,20,3], [1,4,10]] becomes [1203,1410]"
-#     existing_powers = np.floor(np.log10(a))
-#     nrows, ncols = a.shape 
 
-#     cumsum_powers = np.fliplr(np.cumsum(np.fliplr(existing_powers), axis=1))
-
-#     add_powers = [x for x in reversed(range(ncols))]
-#     add_powers = np.tile(add_powers, (nrows, 1))
-
-#     mult_factor = cumsum_powers - existing_powers + add_powers  
-#     summationvector = np.ones((ncols, 1)) 
-#     out = np.matmul(a * 10**mult_factor, summationvector)
-#     return out 
-
-
-
-def idx_unique_multidim(a):
-    "groups row indices in a multidimensional arrays by their unique signature"
-    # a = cols_to_int(a).squeeze() # wrong
-    # a = cols_to_string(a).squeeze() # slow 
-    a = cols_to_int(a).squeeze()
-    sort_idx = np.argsort(a)
-    sort_idx
-    a_sorted = a[sort_idx]
-    unq_first = np.concatenate(([True], a_sorted[1:] != a_sorted[:-1])) # "is the current value different from the previous?". the concat of [True]: because the first occurrence is always True (ie the first time it occur)
-    unq_items = a_sorted[unq_first]
-    unq_count = np.diff(np.nonzero(unq_first)[0]) # np.nonzero(unq_first)[0] gives the indices of first elements in a_sorted
-    unq_idx = np.split(sort_idx, np.cumsum(unq_count))
-    return unq_idx
+# def idx_unique_multidim(a):
+#     "groups row indices in a multidimensional arrays by their unique signature"
+#     # a = cols_to_int(a).squeeze() # wrong
+#     # a = cols_to_string(a).squeeze() # slow 
+#     a = cols_to_int(a).squeeze()
+#     sort_idx = np.argsort(a)
+#     sort_idx
+#     a_sorted = a[sort_idx]
+#     unq_first = np.concatenate(([True], a_sorted[1:] != a_sorted[:-1])) # "is the current value different from the previous?". the concat of [True]: because the first occurrence is always True (ie the first time it occur)
+#     unq_items = a_sorted[unq_first]
+#     unq_count = np.diff(np.nonzero(unq_first)[0]) # np.nonzero(unq_first)[0] gives the indices of first elements in a_sorted
+#     unq_idx = np.split(sort_idx, np.cumsum(unq_count))
+#     return unq_idx
 
 
-# def reshape_rows_reps(a):
-#     "reshape a 3-d array of n_reps x n_rows x n_cols to n_rows x n_reps x n_cols"
-#     n_reps, n_rows, n_cols = a.shape
-#     a = a.reshape(n_reps*n_rows, n_cols)
-#     # extractor indices: for 3 reps, 2 rows: [0,2,4,1,3,5]. to reorder a
-#         # in other words: goes from 0 to (n_reps * n_rows). step sizes are n_rows. starts are the row indices
-#     idx = np.arange(n_reps*n_rows).reshape(n_reps, n_rows).T.reshape(-1,1)
-#     a = np.take_along_axis(a, idx, axis=0)
-#     a = a.reshape(n_rows, n_reps, n_cols)
-#     return a 
-
-# def minhash_signature_np(x, n_reps):
-#     """Make a minhash signature of array x with length n_reps.
-
-#     Inputs
-#     ------
-#     x: axis 0 are observations, columns are binary one-hot encoded vectors
-#     """
-#     # get indices 
-#     indices = np.arange(x.shape[1])
-#     rng = np.random.default_rng(12345) # TODO: this should be defined at class instantiation
-
-#     # expand by n_reps 
-#     indices_mult = np.tile(indices, (n_reps, 1)) # reorder the columns n_reps times 
-#     x_mult = np.tile(x, (n_reps, 1)).reshape((n_reps,) + x.shape) # new shape: (n_resp, x.shape[0], x.shape[1
-
-#     # permute indices and apply to x_mult
-#     permuted_indices = rng.permuted(indices_mult, axis=1)
-#     x_mult_permuted = np.take_along_axis(x_mult, permuted_indices[:, np.newaxis], 2)
-
-#     # for the reduction below, need to have all samples of the same observation in one block
-#     x_mult_permuted = reshape_rows_reps(x_mult_permuted)
-
-#     # make signature
-#     sig = x_mult_permuted.argmax(axis=2)
-#     return sig 
-
-
-# def signature_to_bucket(signature, n_bands):
-#     "Collect items with same bands in buckets"
-#     num_cols = signature.shape[0] # number of documents to classify
-#     bands = np.split(signature, n_bands, axis=1)
-#     buckets = []
-#     for band in bands:
-#         items_buckets = defaultdict(list)
-#         items = np.vsplit(band, num_cols)
-#         for i, item in enumerate(items): # this orders the row indices into groups that have the same signature 
-#             item = tuple(item.flatten().astype(int)) 
-#             items_buckets[item].append(i)  # assign row i to item--ie, groups observations into buckets with the same signature 
-#         buckets.append(items_buckets)
-
-#     return buckets
-
-## new stuff
 def cols_to_int_multidim(a):
     "combine columns in all rows to an integer: [[1,20,3], [1,4,10]] becomes [1203,1410]"
     existing_powers = np.floor(np.log10(a))
@@ -195,7 +121,7 @@ class LSHBase:
 class LSHMinHash(LSHBase):
     "LSH with MinHashing and numpy"
 
-    def __init__(self, mentions, shingle_size, signature_size, band_length, sparse_binary=True):
+    def __init__(self, mentions, shingle_size, signature_size, band_length, sparse_binary=True, seed=3):
         # sparse_binary: should the sparse 0/1 matrix be stored with scipy sparse? takes less memory.
         super().__init__(mentions, shingle_size)
         if signature_size % band_length != 0:
@@ -203,78 +129,35 @@ class LSHMinHash(LSHBase):
         self.signature_size = signature_size 
         self.band_length = band_length 
         self.sparse_binary = sparse_binary
+        self.rng = np.random.default_rng(seed=seed)
     
     def make_signature(self):
         "make array of dense vectors with MinHashing. each row is one mention"
         logging.debug(f"Making signature. vectors shape is {self.vectors.shape}")
-        # pdb.set_trace()
-        templist = []
-        rng = np.random.default_rng(seed=3)
-        i = 0
-        if isinstance(self.vectors, np.ndarray):
-            logging.debug("using binary numpy arrays")
-            while i < self.signature_size:
-                rng.shuffle(self.vectors, axis=1)
-                sig_i = 1 + self.vectors.argmax(axis=1) # add one for the log10 operations in idx_unique_multidim 
-                templist.append(sig_i)
-                i += 1
-            self.signature = np.stack(templist, axis=1)
-        else: # older versions of scipy have not _coo attribute. TODO: fix this
+        # rng = np.random.default_rng(seed=3)
+        # older versions of scipy have not _coo attribute. TODO: fix this
         # elif isinstance(self.vectors, sparse._coo.coo_matrix):
             # not sure how efficient this is. switching a lot between data structures.
-            logging.debug('using binary sparse matrices')
-            rng = np.random.default_rng(seed=3) # TODO: put this to class instantiation
-            # vectors = mylsh.vectors
-            logging.debug("making hyperplanes")
-            hyperplanes = rng.choice([-1, 1], (self.signature_size, self.vectors.shape[1]))
-            # TODO: make vectors a csr matrix (?)
-            hyperplanes = sparse.csr_matrix(hyperplanes)
-            logging.debug("making dot product")
-            products = self.vectors.dot(hyperplanes.transpose())
-            logging.debug("making signature")
-            products = products.toarray()
-            sign = 1 + (products > 0) # TODO: can I change the downstream function for this? now it should be much easier to transform the signatures into a single string?
-            self.signature = sign
-
-            
-    # def make_signature_np(self):
-    #     signature = minhash_signature_np(self.vectors, self.signature_size)
-    #     self.signature = signature + np.ones(signature.shape)  # this is for the log10 operations: do not want to have 0s
+        logging.debug('using binary sparse matrices')
+        # rng = np.random.default_rng(seed=3) # TODO: put this to class instantiation
+        # vectors = mylsh.vectors
+        logging.debug("making hyperplanes")
+        hyperplanes = self.rng.choice([-1, 1], (self.signature_size, self.vectors.shape[1]))
+        # TODO: make vectors a csr matrix (?)
+        hyperplanes = sparse.csr_matrix(hyperplanes)
+        logging.debug("making dot product")
+        products = self.vectors.dot(hyperplanes.transpose())
+        logging.debug("making signature")
+        products = products.toarray()
+        sign = 1 + (products > 0) # TODO: can I change the downstream function for this? now it should be much easier to transform the signatures into a single string?
+        self.signature = sign
 
     def all_candidates_to_all(self):
         "fall-back option to return the non-clustered input: each mention is a candidate coreference for all"
         n_mentions = self.vectors.shape[0]
         self.candidates = [set(range(n_mentions)) for _ in range(n_mentions)]
 
-    # def get_candidates(self): ## TODO: use itertools
-    #     "extract similar candidates for each mention by comparing subsets of the signature"
-    #     logging.debug("getting candidates...")
-    #     n_bands = int(self.signature_size / self.band_length)
-        
-    #     if self.vectors.shape[0] == 1:
-    #         candidates = [set()]
-    #         candidates[0].add(0)
-    #     else:
-    #         bands = np.split(ary=self.signature, indices_or_sections=n_bands, axis=1)
-    #         candidates = [set() for _ in range(self.vectors.shape[0])]
-                        
-    #         # if len(candidates) > 1:
-    #         # TODO: can I speed this up? 
-    #         for band in bands:
-    #             groups = idx_unique_multidim(band)
-    #             groups = [g for g in groups if g.shape[0] > 1]
-    #             for g in groups:
-    #                 g = list(g)
-    #                 for i in g:
-    #                     for j in g:
-    #                         if i != j:
-    #                             candidates[i].add(j)
-    #         # else: # idx_unique_multidim above does not work when there is only one candidate
-    #         #     candidates[0].add(0)
-
-    #     self.candidates = candidates
-
-    def get_candidates_new(self):
+    def get_candidates(self):
         "extract similar candidates for each mention by comparing subsets of the signature"
         logging.debug("getting candidates...")
         n_bands = int(self.signature_size / self.band_length)
@@ -306,19 +189,14 @@ class LSHMinHash(LSHBase):
         logging.debug("encoding to binary")
         self.encode_binary(sparse_output=self.sparse_binary)
         logging.debug("making signature")
+
         if self.vectors.shape[1] == 0: # no signature possible b/c no mention is longer than the shingle size.
             print('self.vectors.shape[1] is 0.')
             self.all_candidates_to_all()
         else:
-            if numpy_signature:
-                self.make_signature_np()
-            else:
-                self.make_signature()
+            self.make_signature()
             logging.debug("getting candidate groups")
-            if candidates == "old":
-                self.get_candidates()
-            elif candidates == "new": # this seems to be slower than the old approach 
-                self.get_candidates_new()
+            self.get_candidates()
         self.time = time.time() - start 
 
     def summarise(self):

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pickle
 import math 
@@ -136,7 +137,7 @@ class TrainingEvaluationDatasets:
         :type search_corefs_in: string.
         :return: dataset with updated candidate entities and p(e|m) scores.
         """
-        print(f"with_coref() is called with search_corefs_in={search_corefs_in}.")
+        logging.info(f"with_coref() is called with search_corefs_in={search_corefs_in}.")
         assert search_corefs_in in ['lsh', 'all']
         for data_name, content in dataset.items():
             if len(content) == 0:

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -133,6 +133,7 @@ class TrainingEvaluationDatasets:
                     input_mentions = [m["mention"] for m in content]
                     lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=2, signature_size=800, band_length=10)
                     lsh_corefs.cluster()
+                    lsh_corefs.efficiency_gain_comparisons()
                     assert len(content) == len(lsh_corefs.candidates)
                     # lsh_corefs.candidates are the input for below. indices refer to index in input_mentions
                     # call lsh here on all mentions 

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -122,7 +122,7 @@ class TrainingEvaluationDatasets:
 
         :return: dataset
         """
-        print(f"with_coref() is called with {search_corefs_in=}.")
+        print(f"with_coref() is called with search_corefs_in={search_corefs_in}.")
         assert search_corefs_in in ['lsh', 'all']
         for data_name, content in dataset.items():
             if len(content) == 0:

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -1,7 +1,8 @@
 import os
 import pickle
-from REL.lsh import LSHRandomProjections
 import math 
+
+from REL.lsh import LSHRandomProjections
 
 class TrainingEvaluationDatasets:
     """

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -2,7 +2,6 @@ import os
 import pickle
 import pdb 
 from REL.lsh import LSHRandomProjections
-import logging
 
 class TrainingEvaluationDatasets:
     """
@@ -115,13 +114,21 @@ class TrainingEvaluationDatasets:
 
     def with_coref(self, dataset, search_corefs_in="all"): # TODO: need to update the calls to with_coref
         """
-        Check if there are coreferences in the given dataset. Use LSH for dimensionality reduction.
+        Check if there are coreferences in the given dataset, and replace
+        the candidate entity of a coreferring mention with the candidates from the main mention.
 
+        Example: If a document contains both "Jimi Hendrix" and "Hendrix" as a mention,
+        then the candidate entities of "Hendrix" will be replaced by the candidate
+        entities of "Jimi Hendrix". 
+
+        Parameters:
+        -----------
         search_corefs_in: either of 'lsh' or all 'all'. 
-        If 'all', search for coreferences among all mentions in document. This is what REL currently does by default.
-        If 'lsh', search for coreferences among a pre-selected set of candidates. The set is calculated with LSH.
+        If 'all', search for coreferences among all mentions in document
+        If 'lsh', search for coreferences among a pre-selected set of candidates. 
+        The set is calculated with LSH.
 
-        :return: dataset
+        :return: dataset with updated candidate entities and p(e|m) scores.
         """
         print(f"with_coref() is called with search_corefs_in={search_corefs_in}.")
         assert search_corefs_in in ['lsh', 'all']
@@ -131,7 +138,7 @@ class TrainingEvaluationDatasets:
             else:
                 if search_corefs_in == 'lsh':
                     input_mentions = [m["mention"] for m in content]
-                    # lsh_corefs = LSHRandomProjections(mentions=input_mentions, shingle_size=2, signature_size=800, band_length=10) # TODO: set optimal parameters here 
+                    # TODO: set optimal parameters here 
                     lsh_corefs = LSHRandomProjections(
                         mentions=input_mentions,
                         shingle_size=2,

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -10,12 +10,18 @@ class TrainingEvaluationDatasets:
     Reading dataset from CoNLL dataset, extracted by https://github.com/dalab/deep-ed/
     """
 
-    def __init__(self, base_url, wiki_version, no_corefs=False):
+    def __init__(self, base_url, wiki_version, search_corefs="all"):
+        """
+        Argument search_corefs: One of 'all' (default), 'lsh', 'off'. 
+            If 'off', no coreference search is done.
+            Otherwise the arguments are passed to the argument `search_corefs_in` in `with_coref`.
+        """
         self.person_names = self.__load_person_names(
             os.path.join(base_url, "generic/p_e_m_data/persons.txt")
         )
         self.base_url = os.path.join(base_url, wiki_version)
-        self.no_corefs = no_corefs
+        assert search_corefs in ['all', 'lsh', 'off']
+        self.search_corefs = search_corefs
 
     def load(self):
         """
@@ -46,8 +52,8 @@ class TrainingEvaluationDatasets:
                 if "Jiří_Třanovský Jiří_Třanovský" in datasets[ds]:
                     del datasets[ds]["Jiří_Třanovský Jiří_Třanovský"]
 
-            if not self.no_corefs:
-                self.with_coref(datasets[ds])
+            if self.search_corefs != "off":
+                self.with_coref(datasets[ds], search_corefs_in=self.search_corefs)
 
         return datasets
 
@@ -106,59 +112,36 @@ class TrainingEvaluationDatasets:
 
         return coref
 
-    def with_coref_old(self, dataset): # TODO: need to update the calls to with_coref
-        """
-        Parent function that checks if there are coreferences in the given dataset.
-
-        :return: dataset
-        """
-        print("with_coref() is called.")
-        for data_name, content in dataset.items():
-            for cur_m in content:
-                coref = self.__find_coref(cur_m, content)
-                if coref is not None and len(coref) > 0:
-                    cur_cands = {}
-                    for m in coref:
-                        for c, p in m["candidates"]:
-                            cur_cands[c] = cur_cands.get(c, 0) + p
-                    for c in cur_cands.keys():
-                        cur_cands[c] /= len(coref)
-                    cur_m["candidates"] = sorted(
-                        list(cur_cands.items()), key=lambda x: x[1]
-                    )[::-1]
-                    cur_m["is_coref"] = 1
-                else:
-                    cur_m["is_coref"] = 0
-
-    def with_coref(self, dataset): # TODO: need to update the calls to with_coref
+    def with_coref(self, dataset, search_corefs_in="all"): # TODO: need to update the calls to with_coref
         """
         Check if there are coreferences in the given dataset. Use LSH for dimensionality reduction.
 
+        search_corefs_in: either of 'lsh' or all 'all'. 
+        If 'all', search for coreferences among all mentions in document. This is what REL currently does by default.
+        If 'lsh', search for coreferences among a pre-selected set of candidates. The set is calculated with LSH.
+
         :return: dataset
         """
-        print("with_coref_lsh() is called.")
+        print(f"with_coref() is called with {search_corefs_in=}.")
+        assert search_corefs_in in ['lsh', 'all']
         for data_name, content in dataset.items():
-            # pdb.set_trace()
-            # handle problem with only 1 input mention -- fall back to previous approach
-            # print(f"len content: {len(content)}")
-            # print(f"data name: {data_name}")
-            # if data_name == '937 OFFICIAL)':
-            #     pdb.set_trace()
             if len(content) == 0:
                 pass 
             else:
-                input_mentions = [m["mention"] for m in content]
-                lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=4, signature_size=50, band_length=2)
-                lsh_corefs.cluster()
-                assert len(content) == len(lsh_corefs.candidates)
-                # lsh_corefs.candidates are the input for below. indices refer to index in input_mentions
-                # call lsh here on all mentions 
-                for cur_m, idx_candidates in zip(content, lsh_corefs.candidates):
-                    idx_candidates = list(idx_candidates) # lsh returns the indices of the candidate coreferences
-                    candidates = [content[i] for i in idx_candidates]
+                if search_corefs_in == 'lsh':
+                    input_mentions = [m["mention"] for m in content]
+                    lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=4, signature_size=50, band_length=2)
+                    lsh_corefs.cluster()
+                    assert len(content) == len(lsh_corefs.candidates)
+                    # lsh_corefs.candidates are the input for below. indices refer to index in input_mentions
+                    # call lsh here on all mentions 
+                for idx_mention, cur_m in enumerate(content):
+                    if search_corefs_in == "lsh":
+                        idx_candidates = list(lsh_corefs.candidates[idx_mention]) # lsh returns the indices of the candidate coreferences
+                        candidates = [content[i] for i in idx_candidates]
+                    elif search_corefs_in == "all":
+                        candidates = content
                     coref = self.__find_coref(cur_m, candidates)
-                    # update __find_coref: use indices from lsh call above 
-                    # pdb.set_trace()
                     if coref is not None and len(coref) > 0:
                         cur_cands = {}
                         for m in coref:

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -2,7 +2,6 @@ import os
 import pickle
 from REL.lsh import LSHRandomProjections
 import math 
-import pdb 
 
 class TrainingEvaluationDatasets:
     """
@@ -146,7 +145,6 @@ class TrainingEvaluationDatasets:
                         n_bands=15, # best recall: 400. acceptable: 200. 
                         band_length=band_length # best recall: 15. acceptable: 15
                     )
-                    pdb.set_trace()
                     lsh_corefs.cluster()
                     assert len(content) == len(lsh_corefs.candidates)
                     # lsh_corefs.candidates are the input for below. indices refer to index in input_mentions

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -9,12 +9,12 @@ class TrainingEvaluationDatasets:
     Reading dataset from CoNLL dataset, extracted by https://github.com/dalab/deep-ed/
     """
 
-    def __init__(self, base_url, wiki_version, use_corefs=True):
+    def __init__(self, base_url, wiki_version, no_corefs=False):
         self.person_names = self.__load_person_names(
             os.path.join(base_url, "generic/p_e_m_data/persons.txt")
         )
         self.base_url = os.path.join(base_url, wiki_version)
-        self.use_corefs = use_corefs
+        self.no_corefs = no_corefs
 
     def load(self):
         """
@@ -45,7 +45,7 @@ class TrainingEvaluationDatasets:
                 if "Jiří_Třanovský Jiří_Třanovský" in datasets[ds]:
                     del datasets[ds]["Jiří_Třanovský Jiří_Třanovský"]
 
-            if self.use_corefs:
+            if not self.no_corefs:
                 self.with_coref(datasets[ds])
 
         return datasets

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 import pdb 
-from REL.lsh import LSHMinHash
+from REL.lsh import LSHRandomProjections
 import logging
 
 class TrainingEvaluationDatasets:
@@ -131,7 +131,7 @@ class TrainingEvaluationDatasets:
             else:
                 if search_corefs_in == 'lsh':
                     input_mentions = [m["mention"] for m in content]
-                    lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=2, signature_size=800, band_length=10) # TODO: set optimal parameters here 
+                    lsh_corefs = LSHRandomProjections(mentions=input_mentions, shingle_size=2, signature_size=800, band_length=10) # TODO: set optimal parameters here 
                     lsh_corefs.cluster()
                     assert len(content) == len(lsh_corefs.candidates)
                     # lsh_corefs.candidates are the input for below. indices refer to index in input_mentions

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -113,22 +113,27 @@ class TrainingEvaluationDatasets:
 
         return coref
 
-    def with_coref(self, dataset, search_corefs_in="all"): # TODO: need to update the calls to with_coref
-        """
-        Check if there are coreferences in the given dataset, and replace
-        the candidate entity of a coreferring mention with the candidates from the main mention.
+    def with_coref(self, dataset, search_corefs_in="all"): 
+        """Replace candidates of coreferring mentions with main mention.
 
-        Example: If a document contains both "Jimi Hendrix" and "Hendrix" as a mention,
+        Check if there are coreferences in the given dataset, and replace
+        the candidate entity of a coreferring mention with the candidates 
+        from the main mention.
+
+        Example
+        -------
+        If a document contains both "Jimi Hendrix" and "Hendrix" as a mention,
         then the candidate entities of "Hendrix" will be replaced by the candidate
         entities of "Jimi Hendrix". 
 
         Parameters:
         -----------
-        search_corefs_in: either of 'lsh' or all 'all'. 
-        If 'all', search for coreferences among all mentions in document
-        If 'lsh', search for coreferences among a pre-selected set of candidates. 
-        The set is calculated with LSH.
-
+        :param search_corefs_in: in which set to search for coreferences.
+            Either of "lsh" or "all".
+            If 'all', search for coreferences among all mentions in document
+            If 'lsh', search for coreferences among a pre-selected set of candidates. 
+            The set is calculated with LSH.
+        :type search_corefs_in: string.
         :return: dataset with updated candidate entities and p(e|m) scores.
         """
         print(f"with_coref() is called with search_corefs_in={search_corefs_in}.")

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -131,7 +131,7 @@ class TrainingEvaluationDatasets:
             else:
                 if search_corefs_in == 'lsh':
                     input_mentions = [m["mention"] for m in content]
-                    lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=2, signature_size=800, band_length=10)
+                    lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=3, signature_size=800, band_length=15)
                     lsh_corefs.cluster()
                     lsh_corefs.efficiency_gain_comparisons()
                     assert len(content) == len(lsh_corefs.candidates)

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -131,7 +131,13 @@ class TrainingEvaluationDatasets:
             else:
                 if search_corefs_in == 'lsh':
                     input_mentions = [m["mention"] for m in content]
-                    lsh_corefs = LSHRandomProjections(mentions=input_mentions, shingle_size=2, signature_size=800, band_length=10) # TODO: set optimal parameters here 
+                    # lsh_corefs = LSHRandomProjections(mentions=input_mentions, shingle_size=2, signature_size=800, band_length=10) # TODO: set optimal parameters here 
+                    lsh_corefs = LSHRandomProjections(
+                        mentions=input_mentions,
+                        shingle_size=2,
+                        n_bands=80,
+                        band_length=10
+                    )
                     lsh_corefs.cluster()
                     assert len(content) == len(lsh_corefs.candidates)
                     # lsh_corefs.candidates are the input for below. indices refer to index in input_mentions

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -137,12 +137,11 @@ class TrainingEvaluationDatasets:
             else:
                 if search_corefs_in == 'lsh':
                     input_mentions = [m["mention"] for m in content]
-                    # TODO: set optimal parameters here 
                     lsh_corefs = LSHRandomProjections(
                         mentions=input_mentions,
                         shingle_size=2,
-                        n_bands=80,
-                        band_length=10
+                        n_bands=400,
+                        band_length=15
                     )
                     lsh_corefs.cluster()
                     assert len(content) == len(lsh_corefs.candidates)

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -147,9 +147,9 @@ class TrainingEvaluationDatasets:
                     band_length = math.ceil(math.log(len(input_mentions)))
                     lsh_corefs = LSHRandomProjections(
                         mentions=input_mentions,
-                        shingle_size=2, # best recall: 2. acceptable: 2
-                        n_bands=15, # best recall: 400. acceptable: 200. 
-                        band_length=band_length # best recall: 15. acceptable: 15
+                        shingle_size=2, 
+                        n_bands=15,  
+                        band_length=band_length 
                     )
                     lsh_corefs.cluster()
                     assert len(content) == len(lsh_corefs.candidates)

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -125,3 +125,6 @@ class TrainingEvaluationDatasets:
                     cur_m["candidates"] = sorted(
                         list(cur_cands.items()), key=lambda x: x[1]
                     )[::-1]
+                    cur_m["is_coref"] = 1
+                else:
+                    cur_m["is_coref"] = 0

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -9,11 +9,12 @@ class TrainingEvaluationDatasets:
     Reading dataset from CoNLL dataset, extracted by https://github.com/dalab/deep-ed/
     """
 
-    def __init__(self, base_url, wiki_version):
+    def __init__(self, base_url, wiki_version, use_corefs=True):
         self.person_names = self.__load_person_names(
             os.path.join(base_url, "generic/p_e_m_data/persons.txt")
         )
         self.base_url = os.path.join(base_url, wiki_version)
+        self.use_corefs = use_corefs
 
     def load(self):
         """
@@ -44,7 +45,8 @@ class TrainingEvaluationDatasets:
                 if "Jiří_Třanovský Jiří_Třanovský" in datasets[ds]:
                     del datasets[ds]["Jiří_Třanovský Jiří_Třanovský"]
 
-            self.with_coref(datasets[ds])
+            if self.use_corefs:
+                self.with_coref(datasets[ds])
 
         return datasets
 
@@ -109,7 +111,7 @@ class TrainingEvaluationDatasets:
 
         :return: dataset
         """
-
+        print("with_coref() is called.")
         for data_name, content in dataset.items():
             for cur_m in content:
                 coref = self.__find_coref(cur_m, content)

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -131,12 +131,10 @@ class TrainingEvaluationDatasets:
             else:
                 if search_corefs_in == 'lsh':
                     input_mentions = [m["mention"] for m in content]
-                    lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=3, signature_size=900, band_length=15)
+                    lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=2, signature_size=800, band_length=10) # TODO: set optimal parameters here 
                     lsh_corefs.cluster()
-                    # lsh_corefs.efficiency_gain_comparisons()
                     assert len(content) == len(lsh_corefs.candidates)
                     # lsh_corefs.candidates are the input for below. indices refer to index in input_mentions
-                    # call lsh here on all mentions 
                 for idx_mention, cur_m in enumerate(content):
                     if search_corefs_in == "lsh":
                         idx_candidates = list(lsh_corefs.candidates[idx_mention]) # lsh returns the indices of the candidate coreferences

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 from REL.lsh import LSHRandomProjections
+import math 
 
 class TrainingEvaluationDatasets:
     """
@@ -137,11 +138,12 @@ class TrainingEvaluationDatasets:
             else:
                 if search_corefs_in == 'lsh':
                     input_mentions = [m["mention"] for m in content]
+                    band_length = math.ceil(math.log(len(input_mentions)))
                     lsh_corefs = LSHRandomProjections(
                         mentions=input_mentions,
-                        shingle_size=2,
-                        n_bands=400,
-                        band_length=15
+                        shingle_size=2, # best recall: 2. acceptable: 2
+                        n_bands=15, # best recall: 400. acceptable: 200. 
+                        band_length=band_length # best recall: 15. acceptable: 15
                     )
                     lsh_corefs.cluster()
                     assert len(content) == len(lsh_corefs.candidates)

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -131,9 +131,9 @@ class TrainingEvaluationDatasets:
             else:
                 if search_corefs_in == 'lsh':
                     input_mentions = [m["mention"] for m in content]
-                    lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=3, signature_size=800, band_length=15)
+                    lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=3, signature_size=900, band_length=15)
                     lsh_corefs.cluster()
-                    lsh_corefs.efficiency_gain_comparisons()
+                    # lsh_corefs.efficiency_gain_comparisons()
                     assert len(content) == len(lsh_corefs.candidates)
                     # lsh_corefs.candidates are the input for below. indices refer to index in input_mentions
                     # call lsh here on all mentions 

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -2,6 +2,7 @@ import os
 import pickle
 from REL.lsh import LSHRandomProjections
 import math 
+import pdb 
 
 class TrainingEvaluationDatasets:
     """
@@ -145,6 +146,7 @@ class TrainingEvaluationDatasets:
                         n_bands=15, # best recall: 400. acceptable: 200. 
                         band_length=band_length # best recall: 15. acceptable: 15
                     )
+                    pdb.set_trace()
                     lsh_corefs.cluster()
                     assert len(content) == len(lsh_corefs.candidates)
                     # lsh_corefs.candidates are the input for below. indices refer to index in input_mentions

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -1,6 +1,5 @@
 import os
 import pickle
-import pdb 
 from REL.lsh import LSHRandomProjections
 
 class TrainingEvaluationDatasets:

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -2,6 +2,7 @@ import os
 import pickle
 import pdb 
 from REL.lsh import LSHMinHash
+import logging
 
 class TrainingEvaluationDatasets:
     """

--- a/src/REL/training_datasets.py
+++ b/src/REL/training_datasets.py
@@ -130,7 +130,7 @@ class TrainingEvaluationDatasets:
             else:
                 if search_corefs_in == 'lsh':
                     input_mentions = [m["mention"] for m in content]
-                    lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=4, signature_size=50, band_length=2)
+                    lsh_corefs = LSHMinHash(mentions=input_mentions, shingle_size=2, signature_size=800, band_length=10)
                     lsh_corefs.cluster()
                     assert len(content) == len(lsh_corefs.candidates)
                     # lsh_corefs.candidates are the input for below. indices refer to index in input_mentions

--- a/src/REL/utils.py
+++ b/src/REL/utils.py
@@ -90,6 +90,7 @@ def process_results(
             idx = ment["sent_idx"]
             start_pos = ment["pos"]
             mention_length = int(ment["end_pos"] - ment["pos"])
+            is_coref = pred['is_coref']
 
             if pred["prediction"] != "NIL":
                 temp = (
@@ -100,6 +101,7 @@ def process_results(
                     pred["conf_ed"],
                     ment["conf_md"] if "conf_md" in ment else 0.0,
                     ment["tag"] if "tag" in ment else "NULL",
+                    is_coref,
                 )
                 res_doc.append(temp)
         res[doc] = res_doc

--- a/tests/test_lsh.py
+++ b/tests/test_lsh.py
@@ -3,17 +3,23 @@
 
 from pathlib import Path
 
-from REL.lsh import vectorize_signature_bands, group_unique_indices, cols_to_int_multidim
+import REL.lsh as lsh 
+# from REL.lsh import vectorize_signature_bands, group_unique_indices, cols_to_int_multidim
 import numpy as np
 import itertools 
 
+
+def test_k_shingle():
+    output = lsh.k_shingle("random string", 5)
+    expected = ["rando", "andom", "ndom ", "dom s", "om st", "m str", " stri", "strin", "tring"]
+    assert output == expected, "shingles not built correctly"
 
 
 def test_cols_to_int_multidim():
     a = np.array([[[1, 20, 3], [1, 4, 10]],
              [[1, 3, 5], [100, 3, 50]]]
             )
-    output = cols_to_int_multidim(a) 
+    output = lsh.cols_to_int_multidim(a) 
     expected = np.array(
         [
             [[1203], [1410]],
@@ -22,13 +28,19 @@ def test_cols_to_int_multidim():
     )
     assert np.all(output == expected), "rows do not convert correctly to integer"
 
-def test_vectorize_signature_bands():
-    a = np.array([[1, 4, 7, 8, 10, 8], [5, 3, 2, 6, 11, 0], [1, 4, 2, 6, 13, 15]])
+def test_signature_to_3d_bands():
+    a = np.array(
+        [
+            [1, 4, 7, 8, 10, 8], 
+            [5, 3, 2, 6, 11, 0], 
+            [1, 4, 2, 6, 13, 15]
+        ]
+    )
 
     n_bands = 2
     n_items = a.shape[0]
     band_length = int(a.shape[1]/n_bands)
-    result = vectorize_signature_bands(a, n_bands=n_bands, band_length=band_length)
+    result = lsh.signature_to_3d_bands(a, n_bands=n_bands, band_length=band_length)
 
     expected = np.vstack(np.split(a, n_bands, axis=1)).reshape(n_bands, n_items, -1)
     assert np.all(result == expected), "signature bands not vectorized correctly"
@@ -39,7 +51,7 @@ def test_group_unique_indices():
     a = np.array([[[1, 4], [1, 4], [5,3], [5, 3], [1 , 2]],
                     [[7,8], [2, 7], [2, 7], [7, 8], [10, 3]]
                   ]) 
-    output = group_unique_indices(a)
+    output = lsh.group_unique_indices(a)
 
     # build expected
     groups_band0 = [[0, 1], [2, 3]]

--- a/tests/test_lsh.py
+++ b/tests/test_lsh.py
@@ -4,7 +4,6 @@
 from pathlib import Path
 
 import REL.lsh as lsh 
-# from REL.lsh import vectorize_signature_bands, group_unique_indices, cols_to_int_multidim
 import numpy as np
 import itertools 
 
@@ -43,9 +42,7 @@ def test_signature_to_3d_bands():
     result = lsh.signature_to_3d_bands(a, n_bands=n_bands, band_length=band_length)
 
     expected = np.vstack(np.split(a, n_bands, axis=1)).reshape(n_bands, n_items, -1)
-    assert np.all(result == expected), "signature bands not vectorized correctly"
-
-
+    assert np.all(result == expected), "signature not correctly converted to 3d bands"
 
 def test_group_unique_indices():
     a = np.array([[[1, 4], [1, 4], [5,3], [5, 3], [1 , 2]],
@@ -69,3 +66,14 @@ def test_group_unique_indices():
     # test 
     assert all([np.all(i==j) for i, j in zip(o, e)]), "unique indices not grouped correctly"
 
+def test_cluster_short_mentions():
+    mentions = ['EEC', 'ABC']
+    max_length = max([len(m) for m in mentions])
+    mylsh = lsh.LSHRandomProjections(
+        mentions=mentions, 
+        shingle_size=max_length + 1, 
+        n_bands=15)
+    mylsh.cluster()
+    expected = [set((0, 1)), set((0, 1))]
+    assert expected == mylsh.candidates, \
+        "lsh fails when shingle size longer than longest input mentions"

--- a/tests/test_lsh.py
+++ b/tests/test_lsh.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+
+from REL.lsh import vectorize_signature_bands, group_unique_indices, cols_to_int_multidim
+import numpy as np
+import itertools 
+
+
+
+def test_cols_to_int_multidim():
+    a = np.array([[[1, 20, 3], [1, 4, 10]],
+             [[1, 3, 5], [100, 3, 50]]]
+            )
+    output = cols_to_int_multidim(a) 
+    expected = np.array(
+        [
+            [[1203], [1410]],
+            [[135], [100350]]
+        ]
+    )
+    assert np.all(output == expected), "rows do not convert correctly to integer"
+
+def test_vectorize_signature_bands():
+    a = np.array([[1, 4, 7, 8, 10, 8], [5, 3, 2, 6, 11, 0], [1, 4, 2, 6, 13, 15]])
+
+    n_bands = 2
+    n_items = a.shape[0]
+    band_length = int(a.shape[1]/n_bands)
+    result = vectorize_signature_bands(a, n_bands=n_bands, band_length=band_length)
+
+    expected = np.vstack(np.split(a, n_bands, axis=1)).reshape(n_bands, n_items, -1)
+    assert np.all(result == expected), "signature bands not vectorized correctly"
+
+
+
+def test_group_unique_indices():
+    a = np.array([[[1, 4], [1, 4], [5,3], [5, 3], [1 , 2]],
+                    [[7,8], [2, 7], [2, 7], [7, 8], [10, 3]]
+                  ]) 
+    output = group_unique_indices(a)
+
+    # build expected
+    groups_band0 = [[0, 1], [2, 3]]
+    groups_band1 = [[1, 2], [0, 3]] 
+    # Notes:
+    # [1,2], [10,3] are not listed because their group is of size 1. 
+    # [2,7] is before [7, 8] because 27 < 78
+    groups_band0 = [np.array(i) for i in groups_band0]
+    groups_band1 = [np.array(i) for i in groups_band1]
+    expected = [groups_band0, groups_band1]
+
+    o = itertools.chain.from_iterable(output)
+    e = itertools.chain.from_iterable(expected)
+
+    # test 
+    assert all([np.all(i==j) for i, j in zip(o, e)]), "unique indices not grouped correctly"
+


### PR DESCRIPTION
Make REL more scalable by using locality-sensitive hashing to reduce search space for coreference search

### Features added

#### 1. add coref switch `search_corefs` to REL
- 3 options
    - "all": for each mention, search all other mentions for a coreference (the current default)
    - "off": do not search for coreferences
    - "lsh": First, find similar mentions with locality-sensitive hashing. Then, search for coreferences in the reduced set of comparison groups. 
- The main adjustment was done in `REL/src/REL/training_datasets.py`, and specifically in the function `with_coref`. The function is called unless `search_corefs="off"`. For the option `lsh`, the function uses the `LSHRandomProjections` class from the new module `lsh.py` in REL.
- `with_coref`  now also returns an indicator for whether a mention is identified as a coreference (along with other attributes for mentions, such as candidates etc), and this is passed on to the final output.
- Behavior
    - default is unchanged: use "all"
    - parameters (see below) for LSH are currently not exposed at the top level for ED, and two of them are hard-coded in `with_coref`


#### 2. `REL.lsh.LSHRandomProjections` implements LSH with Random projections 
- Key parameters: shingle size, number of bands, band length
    - shingle size defines the number of adjacent letters that define one feature
    - the number of bands and the band length determine the length of the binary signature, which will be used to assess the similarity between mentions
- Procedure
    - the signature is cut in n_bands
    - for each band, extract the mentions that have the exact same band
    - the candidate mentions for a mention $i$ are all mentions whose signatures overlap with $i$'s signature in any of the bands
- Choose optimal parameters for LSH (done outside REL, see [here](https://github.com/f-hafner/lsh_coreferences/blob/main/performance_lsh.ipynb))
    - band length = log(number of mentions), following theory
    - shingle size, number of bands
        - load coreferring mentions from AIDA test a
            - mention cur_m is a coreference for mention m if 
                1. m contains cur_m as a word, besides other words. Ie, cur_m = "hendrix", m = "jimi hendrix"
                2. the gold entity of m and cur_m are the same (this is different from `__find_coref` where we do not have ground truth)
        - informally find parameters that maximise recall

#### 3. Efficiency tests in `scripts/` 
- Update `efficiency_test.py`
    - add coref switch and other command-line options
    - when running on local computer (server=False):
        - profile the ED call and save as a dataframe 
        - scaling of ED: run ED on multiply-stacked mentions from test data and time execution
    - all of this is for running on my local computer. which of the options should we keep? what needs to be changed for `server=True`?
- Add script `run_efficiency_tests.sh` that runs `efficiency_test.py` with the different coref options

### Installation (I have not reproduced this recently; let me know if it fails)
```bash
cd rel20
git clone git@github.com:f-hafner/REL.git

# get data; taken from https://github.com/informagi/REL/pull/151
mkdir data
cd data
curl -O http://gem.cs.ru.nl/generic.tar.gz
curl -O http://gem.cs.ru.nl/ed-wiki-2019.tar.gz
curl -O http://gem.cs.ru.nl/wiki_2019.tar.gz
tar zxf wiki_2019.tar.gz
tar zxf ed-wiki-2019.tar.gz
tar zxf generic.tar.gz

# install from branch
cd ../REL
git checkout flavio/coref-lsh
conda create -n rel python=3.7
conda activate rel
pip install -e .[develop]
```

### Testing
```python
pytest tests/test_lsh.py # mostly unit tests
# update `base_url` in `scripts/efficiency_test.py`
python scripts/efficiency_test.py --search_corefs "lsh" # only on local laptop, with CPU
```
### Notes/questions/to dos 
- conventions for docstrings? I have tried to follow the style used in the existing code 
- organization of functions in lsh: should they go elsewhere?
- more tests for end-to-end lsh?
- should we add another option "auto" which automatically selects "lsh" for large documents?
- (are there obvious inefficiencies that have a simple fix?)


I have been sitting on it for long enough now, but let me know if there is something important missing for a review.
