### PR TITLE
separate doc building requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,4 @@ mkdocs:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-   - method: pip
-     path: .
-     extra_requirements:
-      - docs
+     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+markdown-include
+mkdocs
+mkdocs-material
+mkdocstrings[python]


### PR DESCRIPTION
Separate requirements.txt for the doc building process. Hopefully this reduces timeout risk on ReadTheDocs